### PR TITLE
fix(core): pass request headers to local proxy

### DIFF
--- a/packages/core/src/protocol/local.rs
+++ b/packages/core/src/protocol/local.rs
@@ -217,6 +217,7 @@ impl super::Protocol for LocalProtocol {
 
     let client = reqwest::ClientBuilder::new();
     let mut proxy_builder = client.build()?.request(request.method().clone(), &url);
+    proxy_builder = proxy_builder.headers(request.headers().clone());
     proxy_builder = proxy_builder.body(request.body().clone());
     let r = proxy_builder.send().await?;
     let mut response = None;


### PR DESCRIPTION
## Summary

This behavior is required for proper operation on modern bundler servers. For example, when Vite responds with a CSS file, it examines the request headers to determine whether to respond as plain text or a JS script.

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
