### PR TITLE
fix(remote-local): add missing `content-length` header

### DIFF
--- a/packages/remote/local-provider/src/remote.ts
+++ b/packages/remote/local-provider/src/remote.ts
@@ -1,9 +1,8 @@
-/** biome-ignore-all lint/complexity/noBannedTypes: expected */
-
 import os from 'node:os';
 import path from 'node:path';
 import { Readable } from 'node:stream';
 import {
+  bundleFileSize,
   readAllDeployments,
   readBundleMetadata,
   readBundleStream,
@@ -15,6 +14,7 @@ import type { Variables } from './types.js';
 import { getRemoteBundleDeploymentVersion } from './utils.js';
 
 interface Env {
+  // biome-ignore lint/complexity/noBannedTypes: expected
   Bindings: {};
   Variables: Variables;
 }
@@ -56,7 +56,7 @@ export function webviewBundleRemote({ baseDir, allowOtherVersions }: WebviewBund
 
   async function getBundleResponse(c: Context<Env>, bundle: string, version: string) {
     const metadata = await readBundleMetadata({
-      baseDir: '',
+      baseDir: c.get('baseDir'),
       bundle,
       version,
     });
@@ -68,6 +68,9 @@ export function webviewBundleRemote({ baseDir, allowOtherVersions }: WebviewBund
     if (metadata?.signature != null) {
       c.header('webview-bundle-signature', metadata.signature);
     }
+
+    const size = await bundleFileSize({ baseDir: c.get('baseDir'), bundle, version });
+    c.header('content-length', String(size));
 
     if (c.req.method.toUpperCase() === 'HEAD') {
       return c.body(null);

--- a/packages/remote/local-provider/src/remote.ts
+++ b/packages/remote/local-provider/src/remote.ts
@@ -2,7 +2,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { Readable } from 'node:stream';
 import {
-  bundleFileSize,
+  getBundleFileSize,
   readAllDeployments,
   readBundleMetadata,
   readBundleStream,
@@ -69,7 +69,7 @@ export function webviewBundleRemote({ baseDir, allowOtherVersions }: WebviewBund
       c.header('webview-bundle-signature', metadata.signature);
     }
 
-    const size = await bundleFileSize({ baseDir: c.get('baseDir'), bundle, version });
+    const size = await getBundleFileSize({ baseDir: c.get('baseDir'), bundle, version });
     c.header('content-length', String(size));
 
     if (c.req.method.toUpperCase() === 'HEAD') {

--- a/packages/remote/local/src/api/bundles.ts
+++ b/packages/remote/local/src/api/bundles.ts
@@ -16,6 +16,16 @@ export function readBundleStream({ baseDir, bundle, version }: ReadBundleStreamP
   return createReadStream(filePath);
 }
 
+export async function getBundleFileSize({
+  baseDir,
+  bundle,
+  version,
+}: ReadBundleStreamParams): Promise<number> {
+  const filePath = getBundleFilePath(baseDir, bundle, version);
+  const stats = await fs.stat(filePath);
+  return stats.size;
+}
+
 interface WriteBundleParams {
   baseDir: string;
   bundle: string;

--- a/packages/remote/local/src/api/index.ts
+++ b/packages/remote/local/src/api/index.ts
@@ -1,6 +1,7 @@
 export type { BundleMetadataFile } from './bundles.js';
 export {
   BundleMetadataFileSchema,
+  getBundleFileSize,
   readBundleMetadata,
   readBundleStream,
   writeBundle,


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/webview-bundle/webview-bundle/pull/162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

