### PR TITLE
fix(core): set total bytes as optional

### DIFF
--- a/packages/cli/src/api/builtin.ts
+++ b/packages/cli/src/api/builtin.ts
@@ -187,7 +187,7 @@ function buildProgress() {
     totalBytes,
     endpoint,
   }) => {
-    if (progress == null) {
+    if (progress == null || totalBytes == null) {
       return;
     }
     const bundleName = findBundleNameFromEndpoint(endpoint);

--- a/packages/cli/src/api/builtin.ts
+++ b/packages/cli/src/api/builtin.ts
@@ -77,7 +77,7 @@ export async function builtin(params: BuiltinParams): Promise<BundleManifestData
   const progressBars = new Map<string, SingleBar>();
   remote = new Remote(remoteEndpoint, {
     onDownload: ({ downloadedBytes, totalBytes, endpoint }) => {
-      if (progress == null) {
+      if (progress == null || totalBytes == null) {
         return;
       }
       const bundleName = findBundleNameFromEndpoint(endpoint);

--- a/packages/cli/src/commands/download.ts
+++ b/packages/cli/src/commands/download.ts
@@ -114,7 +114,7 @@ Set this to \`false\` (or pass "--no-write") just for simulating operation.
       : null;
     const remote = new Remote(endpoint, {
       onDownload: data => {
-        if (progress?.isActive !== true) {
+        if (progress?.isActive !== true && data.totalBytes != null) {
           progress?.start(data.totalBytes, data.downloadedBytes);
         } else {
           progress?.update(data.downloadedBytes);

--- a/packages/core/src/remote/remote.rs
+++ b/packages/core/src/remote/remote.rs
@@ -45,7 +45,7 @@ pub struct RemoteError {
   pub message: Option<String>,
 }
 
-type OnDownload = dyn Fn(u64, u64, String) + Send + Sync + 'static;
+type OnDownload = dyn Fn(u64, Option<u64>, String) + Send + Sync + 'static;
 
 /// Configuration for remote operations.
 #[derive(Default, Clone)]
@@ -84,7 +84,7 @@ impl RemoteBuilder {
   /// Set download progress callback.
   pub fn on_download<F>(mut self, on_download: F) -> Self
   where
-    F: Fn(u64, u64, String) + Send + Sync + 'static,
+    F: Fn(u64, Option<u64>, String) + Send + Sync + 'static,
   {
     self.config.on_download = Some(Arc::new(on_download));
     self
@@ -250,10 +250,13 @@ impl Remote {
       return Err(self.parse_err(resp).await);
     }
     let info = self.parse_info(&resp)?;
-    let total_size = resp.content_length().unwrap();
+    let total_size = resp.content_length();
     let mut stream = resp.bytes_stream();
     let mut downloaded_bytes: u64 = 0;
-    let mut data = Vec::with_capacity(total_size as usize);
+    let mut data = match total_size {
+      Some(size) => Vec::with_capacity(size as usize),
+      None => Vec::new(),
+    };
     while let Some(chunk_result) = stream.next().await {
       let chunk = chunk_result?;
       data.append(&mut chunk.to_vec());

--- a/packages/core/src/source/source.rs
+++ b/packages/core/src/source/source.rs
@@ -477,6 +477,9 @@ fn is_valid_path_component(value: &str) -> bool {
     && value
       .chars()
       .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_'))
+    // Windows strips a trailing `.`, which would collapse distinct names (e.g. "app." and "app")
+    // onto the same file. Reject it so resolved filepaths stay unambiguous across platforms.
+    && !value.ends_with('.')
     && !is_windows_reserved_name(value)
 }
 
@@ -544,6 +547,9 @@ mod tests {
       "prn",
       "nul.txt",
       "con.foo.bar",
+      // Trailing dot — Windows strips it, collapsing distinct names onto the same file.
+      "app.",
+      "1.0.0.",
     ] {
       assert!(!is_valid_path_component(bad), "{bad:?} should be invalid");
     }

--- a/packages/node/index.d.cts
+++ b/packages/node/index.d.cts
@@ -1381,7 +1381,7 @@ export interface RemoteBundleInfo {
  */
 export interface RemoteOnDownloadData {
   downloadedBytes: number
-  totalBytes: number
+  totalBytes?: number
   endpoint: string
 }
 

--- a/packages/node/index.d.ts
+++ b/packages/node/index.d.ts
@@ -1381,7 +1381,7 @@ export interface RemoteBundleInfo {
  */
 export interface RemoteOnDownloadData {
   downloadedBytes: number
-  totalBytes: number
+  totalBytes?: number
   endpoint: string
 }
 

--- a/packages/node/src/remote/remote.rs
+++ b/packages/node/src/remote/remote.rs
@@ -38,7 +38,7 @@ pub struct RemoteOptions {
 #[napi(object)]
 pub struct RemoteOnDownloadData {
   pub downloaded_bytes: u32,
-  pub total_bytes: u32,
+  pub total_bytes: Option<u32>,
   pub endpoint: String,
 }
 
@@ -171,7 +171,7 @@ impl Remote {
           let on_download_fn = Arc::clone(&on_download);
           let _ = on_download_fn.fire_and_forgot(RemoteOnDownloadData {
             downloaded_bytes: downloaded_bytes as u32,
-            total_bytes: total_bytes as u32,
+            total_bytes: total_bytes.map(|t| t as u32),
             endpoint,
           });
         });

--- a/packages/tauri/src/config.rs
+++ b/packages/tauri/src/config.rs
@@ -102,7 +102,7 @@ impl Remote {
 
   pub fn on_download<F>(mut self, on_download: F) -> Self
   where
-    F: Fn(u64, u64, String) + Send + Sync + 'static,
+    F: Fn(u64, Option<u64>, String) + Send + Sync + 'static,
   {
     self.builder = self.builder.on_download(on_download);
     self


### PR DESCRIPTION
## Summary

When remote not sending `content-length` header, the remote downloader will be panic because previous behavior does unwrap the `content-length` header value to get the total bytes information.

This PR fixes that download callback accepts the `total_bytes` as optional.

## Test Plan

Should pass CI.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/webview-bundle/webview-bundle/pull/163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

