### PR TITLE
fix(tauri): fix build failed which cause from `alloc-no-stdlib`

### DIFF
--- a/packages/tauri/Cargo.toml
+++ b/packages/tauri/Cargo.toml
@@ -17,3 +17,8 @@ wvb       = { workspace = true, features = ["source", "protocol", "protocol-loca
 
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
+
+# Resolver-only pin (never compiled): brotli 8.0.3 (pulled via tauri) needs alloc-no-stdlib 2.x,
+# but alloc-stdlib 0.2.3 widened its requirement to allow the incompatible alloc-no-stdlib 3.0.0,
+[target.'cfg(any())'.dependencies]
+alloc-no-stdlib = "=2.0.4"

--- a/packages/tauri/Cargo.toml
+++ b/packages/tauri/Cargo.toml
@@ -18,7 +18,8 @@ wvb       = { workspace = true, features = ["source", "protocol", "protocol-loca
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
 
-# Resolver-only pin (never compiled): brotli 8.0.3 (pulled via tauri) needs alloc-no-stdlib 2.x,
-# but alloc-stdlib 0.2.3 widened its requirement to allow the incompatible alloc-no-stdlib 3.0.0,
+# Resolver-only pins (never compiled): tauri pulls brotli 8.0.3, which caps alloc-no-stdlib at 2.x.
+# But two of brotli's deps shipped releases that jumped to the incompatible alloc-no-stdlib 3.0.0
 [target.'cfg(any())'.dependencies]
-alloc-no-stdlib = "=2.0.4"
+alloc-stdlib        = "=0.2.2"
+brotli-decompressor = "=5.0.1"


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/webview-bundle/webview-bundle/pull/165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

