### PR TITLE
refactor(cli,config): collapse pack outDir + outFileName into single outFile

### DIFF
--- a/packages/cli/src/api/builtin.ts
+++ b/packages/cli/src/api/builtin.ts
@@ -26,8 +26,7 @@ import {
   type ResolvedConfig,
   resolveBundleName,
   resolveConfig,
-  resolveOutDir,
-  resolveOutFileName,
+  resolveOutFile,
   resolveVersion,
 } from '../config.js';
 import { c } from '../console.js';
@@ -247,18 +246,15 @@ async function* loadLocalBundles(
   for (const w of resolvedWorkspaces) {
     let bundle: Bundle;
 
-    const outFile = resolveOutFileName(w.config);
-    const outDir = resolveOutDir(w.config);
+    const outFile = resolveOutFile(w.config);
 
     if (outFile == null) {
-      const message = `Out file is not specified. Set "pack.outFileName" in the config file. (from "${w.dir}" workspace)`;
+      const message = `Out file is not specified. Set "pack.outFile" in the config file. (from "${w.dir}" workspace)`;
       options.logger?.error(message);
       throw new ApiError(message);
     }
 
-    const outFilePath = withWvbExtension(
-      path.isAbsolute(outFile) ? outFile : path.join(w.config.root, outDir, outFile)
-    );
+    const outFilePath = withWvbExtension(toAbsolutePath(outFile, w.config.root));
 
     const bundleName = await resolveBundleName(w.config, target.bundleName, {
       file: outFilePath,
@@ -301,7 +297,6 @@ async function* loadLocalBundles(
       const packResult = await pack({
         srcDir,
         outFile,
-        outDir,
         overwrite,
         // Honor the caller's `write` flag so `--no-write` is a true simulation (pack still builds the
         // bundle in memory, it just doesn't touch disk).

--- a/packages/cli/src/api/pack.ts
+++ b/packages/cli/src/api/pack.ts
@@ -14,7 +14,10 @@ import { ApiError } from './error.js';
 
 export interface PackParams {
   srcDir: string;
-  outDir: string;
+  /**
+   * Output path for the archive, relative to `cwd` (or absolute).
+   * The ".wvb" extension is appended automatically when omitted.
+   */
   outFile: string;
   ignores?: IgnoreConfig[];
   headers?: HeadersConfig[];
@@ -37,7 +40,6 @@ export async function pack(params: PackParams): Promise<PackResult> {
   const {
     srcDir: srcDirInput,
     outFile: outFileInput,
-    outDir: outDirInput,
     ignores,
     headers,
     write = true,
@@ -81,10 +83,7 @@ export async function pack(params: PackParams): Promise<PackResult> {
     builder.insertEntry(withSlash(file), data, undefined, headers);
   }
 
-  const outDir = toAbsolutePath(outDirInput, cwd);
-  const outFilePath = withWvbExtension(
-    path.isAbsolute(outFileInput) ? outFileInput : path.join(outDir, outFileInput)
-  );
+  const outFilePath = withWvbExtension(toAbsolutePath(outFileInput, cwd));
   const displayOutFile = path.relative(cwd, outFilePath);
 
   const bundle = builder.build();

--- a/packages/cli/src/commands/pack.ts
+++ b/packages/cli/src/commands/pack.ts
@@ -3,7 +3,7 @@ import { Command, Option } from 'clipanion';
 import { isNotNil } from 'es-toolkit';
 import { isBoolean } from 'typanion';
 import { pack } from '../api/pack.js';
-import { resolveConfig, resolveOutDir, resolveOutFileName } from '../config.js';
+import { resolveConfig, resolveOutFile } from '../config.js';
 import { BaseCommand } from './base.js';
 
 export class PackCommand extends BaseCommand {
@@ -13,7 +13,7 @@ export class PackCommand extends BaseCommand {
     description: 'Pack webview bundle archive.',
     examples: [
       ['A basic usage', '$0 pack ./dist'],
-      ['Specify outfile path', '$0 pack ./dist --outfile ./dist.wvb'],
+      ['Specify outfile path', '$0 pack ./dist --outfile ./out/app.wvb'],
       ['Ignore files with patterns', `$0 pack ./dist --ignore='*.txt' --ignore='node_modules/**'`],
       ['Set headers for files', `$0 pack ./dist --header='*.html' 'cache-control' 'max-age=3600'`],
     ],
@@ -21,12 +21,9 @@ export class PackCommand extends BaseCommand {
 
   readonly srcDir = Option.String({ name: 'SRC_DIR', required: false });
   readonly outFile = Option.String('--outfile,--out-file,-O', {
-    description: `Outfile name to create Webview Bundle archive.
-If not provided, default to name field in "package.json" with normalized.
+    description: `Output path for the Webview Bundle archive (relative to cwd, or absolute).
+If not provided, defaults to ".wvb/<name>" where <name> comes from the "name" field in "package.json".
 If extension is not set, will automatically append ".wvb" extension.`,
-  });
-  readonly outDir = Option.String('--outdir,--out-dir', {
-    description: 'Output directory for Webview Bundle archive. [Default: "./.wvb"]',
   });
   readonly ignores = Option.Array('--ignore', {
     description: 'Ignore patterns. Glob supported.',
@@ -61,19 +58,17 @@ Set this to \`false\` (or pass "--no-write") just for simulating operation.
       configFile: this.configFile,
     });
     const srcDir = this.srcDir ?? config.pack?.srcDir ?? './dist';
-    const outFile = this.outFile ?? resolveOutFileName(config);
+    const outFile = this.outFile ?? resolveOutFile(config);
     if (outFile == null) {
       this.logger.error(
         'Out file is not specified. Set "pack.outFile" in the config file or pass "--outfile,--out-file,-O" as a CLI argument.'
       );
       return 1;
     }
-    const outDir = this.outDir ?? resolveOutDir(config);
     const overwrite = this.overwrite ?? config.pack?.overwrite ?? true;
     await pack({
       srcDir,
       outFile,
-      outDir,
       ignores: [this.ignores, config.pack?.ignore].filter(isNotNil),
       headers: [
         config.pack?.headers,

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1,7 +1,7 @@
 import { Command, Option } from 'clipanion';
 import { cascade, isBoolean, isInExclusiveRange, isInteger, isNumber } from 'typanion';
 import { serve } from '../api/serve.js';
-import { resolveConfig, resolveOutFileName } from '../config.js';
+import { resolveConfig, resolveOutFile } from '../config.js';
 import { isColorEnabled } from '../console.js';
 import { BaseCommand } from './base.js';
 
@@ -48,10 +48,10 @@ export class ServeCommand extends BaseCommand {
       root: this.cwd,
       configFile: this.configFile,
     });
-    const file = this.file ?? resolveOutFileName(config);
+    const file = this.file ?? config.serve?.file ?? resolveOutFile(config);
     if (file == null) {
       this.logger.error(
-        'Webview Bundle file is not specified. Set "serve.file" in the config file ' +
+        'Webview Bundle file is not specified. Set "serve.file" (or "pack.outFile") in the config file ' +
           'or pass [FILE] as a CLI argument.'
       );
       return 1;

--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -7,8 +7,7 @@ import {
   type ResolvedConfig,
   resolveBundleName,
   resolveConfig,
-  resolveOutDir,
-  resolveOutFileName,
+  resolveOutFile,
   resolveVersion,
 } from '../config.js';
 import { c } from '../console.js';
@@ -108,7 +107,7 @@ This option can be used when the deploy options is enabled.`,
     const file = this.resolveFile(config);
     if (file == null) {
       this.logger.error(
-        'Webview Bundle file is not specified. Set "pack.outFileName" in the config file ' +
+        'Webview Bundle file is not specified. Set "pack.outFile" in the config file ' +
           'or pass "--file,-F" as a CLI argument.'
       );
       return 1;
@@ -117,12 +116,10 @@ This option can be used when the deploy options is enabled.`,
     const packBeforeUpload = this.pack ?? config.remote?.packBeforeUpload ?? true;
     if (packBeforeUpload) {
       const srcDir = config.pack?.srcDir ?? './dist';
-      const outDir = resolveOutDir(config);
       const overwrite = config.pack?.overwrite ?? true;
       await pack({
         srcDir,
         outFile: file,
-        outDir,
         overwrite,
         write: true,
         cwd: config.root,
@@ -175,13 +172,7 @@ This option can be used when the deploy options is enabled.`,
     if (this.file != null) {
       return withWvbExtension(this.file);
     }
-    const defaultFile = resolveOutFileName(config);
-    if (defaultFile != null) {
-      if (path.isAbsolute(defaultFile)) {
-        return withWvbExtension(defaultFile);
-      }
-      return withWvbExtension(path.join(resolveOutDir(config), defaultFile));
-    }
-    return undefined;
+    const outFile = resolveOutFile(config);
+    return outFile != null ? withWvbExtension(outFile) : undefined;
   }
 }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -205,13 +205,21 @@ export async function resolveConfig(inlineConfig: InlineConfig): Promise<Resolve
   return resolved;
 }
 
-export function resolveOutFileName(config: ResolvedConfig): string | undefined {
-  if (config.pack?.outFileName != null) {
-    return config.pack.outFileName;
+/**
+ * Resolve the output path for the packed Webview Bundle.
+ *
+ * Returns the configured `pack.outFile` as-is, otherwise falls back to
+ * ".wvb/<name>" derived from "package.json". The path is relative to the config
+ * root (unless absolute) and has no ".wvb" extension forced here — callers apply
+ * `withWvbExtension`/`toAbsolutePath` as needed.
+ */
+export function resolveOutFile(config: ResolvedConfig): string | undefined {
+  if (config.pack?.outFile != null) {
+    return config.pack.outFile;
   }
   const pkgName = config.packageJson?.name;
   if (pkgName != null) {
-    return getDefaultBundleName(pkgName);
+    return path.join('.wvb', getDefaultBundleName(pkgName));
   }
   return undefined;
 }
@@ -219,10 +227,6 @@ export function resolveOutFileName(config: ResolvedConfig): string | undefined {
 function getDefaultBundleName(pkgName: string): string {
   const name = pkgName.includes('/') ? pkgName.split('/')[1]! : pkgName;
   return name;
-}
-
-export function resolveOutDir(config: ResolvedConfig): string {
-  return config.pack?.outDir ?? './.wvb';
 }
 
 export async function resolveVersion(

--- a/packages/config/src/pack.ts
+++ b/packages/config/src/pack.ts
@@ -18,15 +18,15 @@ export interface PackConfig {
    */
   srcDir?: string;
   /**
-   * Directory that out-file should be created.
-   * @default "./.wvb"
+   * Output path for the Webview Bundle archive.
+   *
+   * Resolved relative to the config root (or used as-is when absolute).
+   * The ".wvb" extension is appended automatically when omitted.
+   *
+   * If not provided, defaults to ".wvb/<name>", where `<name>` is derived from
+   * the "name" field in "package.json" (scope stripped).
    */
-  outDir?: string;
-  /**
-   * Outfile name to create Webview Bundle archive.
-   * If not provided, default to name field in "package.json" with normalized.
-   */
-  outFileName?: string;
+  outFile?: string;
   /**
    * Overwrite out-file if file is already exists
    * @default true


### PR DESCRIPTION
## Summary

Collapses the pack output configuration from **two** fields — `pack.outDir` (directory) + `pack.outFileName` (name), which consumers joined together — into a **single `pack.outFile`** (a full path, relative to the config root or absolute; `.wvb` appended automatically).

### Motivation

The two-field model was confusing on the CLI surface. A path-like `--outfile` value was silently joined onto `outDir`:

```
$ wvb pack ./dist --outfile ./dist.wvb   # documented example
# wrote to .wvb/dist.wvb, NOT ./dist.wvb  ← surprising, contradicts the example
```

The config field names (`outFileName` / `outDir`) implied "name + directory", but the `--outfile` flag and its example implied "path". A single `outFile` removes the ambiguity, and one `resolveOutFile` becomes the single source of truth for `pack` / `upload` / `serve` / `builtin`.

### Latent bugs fixed along the way

The duplicated `join(outDir, name)` logic across commands had drifted:

- **upload (default):** path was double-joined as `.wvb/.wvb/<name>.wvb`, so `pack` wrote a different path than `upload` read.
- **upload (`--file`):** a relative `--file` resolved inconsistently between the pack step and the upload step.
- **serve (default):** the default bundle was looked up by bare name, missing the `.wvb/` directory.
- **serve (`config.serve.file`):** never read despite being in the schema and the error message. Now honored with precedence **CLI arg > `serve.file` > `pack.outFile`**, matching the existing `ServeConfig.file` JSDoc.

### Tests

- `resolveOutFile`: configured value, package.json fallback (`.wvb/<name>`, scope stripped), undefined cases.
- pack `outFile` resolution: bare name, existing `.wvb`, relative path with dirs, absolute path.

`yarn typecheck` + `yarn vitest run` (14 tests) pass for `@wvb/cli`; `@wvb/config` builds clean.

## ⚠️ Breaking changes

- `pack.outDir` and `pack.outFileName` are removed in favor of `pack.outFile`.
- The `--outdir` / `--out-dir` flag is removed from `wvb pack`.
- A bare `--outfile <name>` now resolves against **cwd**, not the old `outDir`. The no-flag default (`./.wvb/<name>.wvb`) is unchanged, so only bare-name `--outfile` callers are affected.

> `extract --outdir`, `builtin.outDir`, and the ffi `--out-dir` are unrelated concepts and intentionally untouched.

## Review

Reviewed via a multi-agent adversarial pass (correctness / completeness / edge-cases / DX-docs, each finding independently verified): **0 confirmed issues**; the `serve.file` fix above came out of that pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/webview-bundle/webview-bundle/pull/166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

