### PR TITLE
fix(xtask): ignore package json which don't have `version` field

### DIFF
--- a/xtask/versioned-file.ts
+++ b/xtask/versioned-file.ts
@@ -42,16 +42,18 @@ export class VersionedFile {
       }
     );
     const versionedFiles = await Promise.all(files.map(x => VersionedFile.load(x)));
-    return versionedFiles;
+    return versionedFiles.filter((x): x is VersionedFile => x != null);
   }
 
-  static async load(filepath: string): Promise<VersionedFile> {
+  static async load(filepath: string): Promise<VersionedFile | null> {
     const absolutePath = path.join(ROOT_DIR, filepath);
     const filename = path.basename(absolutePath);
     const content = await fs.readFile(absolutePath, 'utf8');
     switch (filename) {
-      case 'package.json':
-        return new VersionedFile('package.json', new PackageJson(filepath, content));
+      case 'package.json': {
+        const pkg = PackageJson.create(filepath, content);
+        return pkg == null ? null : new VersionedFile('package.json', pkg);
+      }
       case 'Cargo.toml':
         return new VersionedFile('Cargo.toml', new Cargo(filepath, content));
       default:
@@ -177,15 +179,19 @@ class PackageJson implements PackageManager {
   private readonly _path: string;
   private readonly raw: string;
 
-  constructor(path: string, raw: string) {
+  static create(path: string, raw: string): PackageJson | null {
     const parsed: PackageJsonType = JSON.parse(raw);
+    if (parsed.version == null) {
+      return null;
+    }
     if (parsed.name == null) {
       throw new Error('"name" field is required in package.json');
     }
-    if (parsed.version == null) {
-      throw new Error('"version" field is required in package.json');
-    }
-    this.json = parsed;
+    return new PackageJson(path, parsed, raw);
+  }
+
+  private constructor(path: string, json: PackageJsonType, raw: string) {
+    this.json = json;
     this._path = path;
     this.raw = raw;
   }


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/webview-bundle/webview-bundle/pull/179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

