### PR TITLE
fix(cli): set `--deploy` option default value as false in `upload` command

### DIFF
--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -57,7 +57,7 @@ The upload process includes:
   readonly deploy = Option.String('--deploy', false, {
     tolerateBoolean: true,
     validator: isBoolean(),
-    description: 'Deploy the bundle to the remote endpoint after upload.',
+    description: 'Deploy the bundle to the remote endpoint after upload. [Default: false]',
   });
   readonly channel = Option.String('--channel', {
     description: `Release channel to manage and distribute different stability versions. (e.g. "beta", "alpha")

--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -54,7 +54,7 @@ The upload process includes:
     validator: isBoolean(),
     description: 'Overwrite if the same version already exists on remote.',
   });
-  readonly deploy = Option.String('--deploy', true, {
+  readonly deploy = Option.String('--deploy', false, {
     tolerateBoolean: true,
     validator: isBoolean(),
     description: 'Deploy the bundle to the remote endpoint after upload.',


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/webview-bundle/webview-bundle/pull/181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

