### PR TITLE
fix(remote-cloudflare): set default region as `auto`

### DIFF
--- a/packages/remote/cloudflare/src/uploader.ts
+++ b/packages/remote/cloudflare/src/uploader.ts
@@ -18,6 +18,7 @@ class CloudflareRemoteUploaderImpl implements BaseRemoteUploader {
       ...config,
       s3ClientConfig: {
         ...config.s3ClientConfig,
+        region: config.s3ClientConfig?.region ?? 'auto',
         endpoint:
           config.s3ClientConfig?.endpoint ?? `https://${accountId}.r2.cloudflarestorage.com`,
       },


### PR DESCRIPTION
## Summary

Cloudflare R2 bucket requires region value to be `auto` .

## Test Plan

<!-- What demonstrates that your implementation is correct? -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/webview-bundle/webview-bundle/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

