### PR TITLE
feat(xtask): add /merge-lockfile bot to auto-resolve yarn.lock conflicts

### DIFF
--- a/.github/workflows/resolve-lockfile.yaml
+++ b/.github/workflows/resolve-lockfile.yaml
@@ -8,7 +8,6 @@ permissions:
   contents: write
   pull-requests: write
 concurrency:
-  # One resolve per PR at a time; let an in-flight run finish rather than cancel a push mid-way.
   group: resolve-lockfile-${{ github.event.issue.number }}
   cancel-in-progress: false
 env:

--- a/.github/workflows/resolve-lockfile.yaml
+++ b/.github/workflows/resolve-lockfile.yaml
@@ -1,0 +1,46 @@
+name: resolve-lockfile
+# Auto-resolve a PR whose only merge conflict with its base branch is `yarn.lock`.
+# Trigger: a maintainer comments `/merge-lockfile` on the PR.
+on:
+  issue_comment:
+    types: [created]
+permissions:
+  contents: write
+  pull-requests: write
+concurrency:
+  # One resolve per PR at a time; let an in-flight run finish rather than cancel a push mid-way.
+  group: resolve-lockfile-${{ github.event.issue.number }}
+  cancel-in-progress: false
+env:
+  LEFTHOOK: 0
+jobs:
+  resolve:
+    # Only act on PR comments that start with the command. `issue_comment` workflows always run
+    # from the default branch, so this gate cannot be bypassed by editing the workflow in the PR.
+    # `author_association` is only a coarse pre-filter (it includes read-only org members) — the
+    # command itself verifies the commenter's *actual* write access via the API.
+    if: >-
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/merge-lockfile') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # 6.0.1
+        with:
+          fetch-depth: 0
+          # Prefer a bot token (PAT or GitHub App installation token) so the resulting push
+          # re-triggers `ci.yaml` — pushes authenticated with the default GITHUB_TOKEN do NOT start
+          # new workflow runs. Falls back to GITHUB_TOKEN (push works, but CI will not re-run).
+          token: ${{ secrets.LOCKFILE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: Setup Node.js
+        uses: ./.github/actions/node-setup
+      - name: Resolve yarn.lock conflict
+        env:
+          GITHUB_TOKEN: ${{ secrets.LOCKFILE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          COMMENT_USER: ${{ github.event.comment.user.login }}
+          # True only when a dedicated bot token is configured — a push made with the default
+          # GITHUB_TOKEN does not re-trigger `ci.yaml`, and the bot says so in its comment.
+          CI_WILL_RERUN: ${{ secrets.LOCKFILE_BOT_TOKEN != '' }}
+        run: node ./xtask/cli.ts resolve-lockfile --pr "${{ github.event.issue.number }}"

--- a/.github/workflows/resolve-lockfile.yaml
+++ b/.github/workflows/resolve-lockfile.yaml
@@ -15,10 +15,6 @@ env:
   LEFTHOOK: 0
 jobs:
   resolve:
-    # Only act on PR comments that start with the command. `issue_comment` workflows always run
-    # from the default branch, so this gate cannot be bypassed by editing the workflow in the PR.
-    # `author_association` is only a coarse pre-filter (it includes read-only org members) — the
-    # command itself verifies the commenter's *actual* write access via the API.
     if: >-
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/merge-lockfile') &&
@@ -29,18 +25,12 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # 6.0.1
         with:
           fetch-depth: 0
-          # Prefer a bot token (PAT or GitHub App installation token) so the resulting push
-          # re-triggers `ci.yaml` — pushes authenticated with the default GITHUB_TOKEN do NOT start
-          # new workflow runs. Falls back to GITHUB_TOKEN (push works, but CI will not re-run).
-          token: ${{ secrets.LOCKFILE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
       - name: Setup Node.js
         uses: ./.github/actions/node-setup
       - name: Resolve yarn.lock conflict
         env:
-          GITHUB_TOKEN: ${{ secrets.LOCKFILE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           COMMENT_ID: ${{ github.event.comment.id }}
           COMMENT_USER: ${{ github.event.comment.user.login }}
-          # True only when a dedicated bot token is configured — a push made with the default
-          # GITHUB_TOKEN does not re-trigger `ci.yaml`, and the bot says so in its comment.
-          CI_WILL_RERUN: ${{ secrets.LOCKFILE_BOT_TOKEN != '' }}
         run: node ./xtask/cli.ts resolve-lockfile --pr "${{ github.event.issue.number }}"

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -44,3 +44,31 @@ This is used in conjunction with the artifact action in GitHub Actions.
 ### Attw
 
 Run [attw](https://github.com/arethetypeswrong/arethetypeswrong.github.io) to check npm package is correct before the publishing.
+
+### Resolving lockfile conflicts
+
+When several PRs are open at once, rebasing onto the base branch routinely produces a `yarn.lock`
+conflict even though every `package.json` merges cleanly. `xtask resolve-lockfile --pr <number>`
+fixes that mechanically: it merges the base branch into the PR head, and **only if `yarn.lock` is
+the sole conflict**, takes the base branch's lockfile, runs `yarn install` to regenerate it against
+the merged `package.json` set, commits the merge, and pushes it back to the PR branch. Any other
+conflict aborts and asks for a human; the bot never merges the PR itself.
+
+The [`resolve-lockfile` workflow](../.github/workflows/resolve-lockfile.yaml) drives it: a maintainer
+opens a PR comment **starting with** `/merge-lockfile`. The workflow pre-filters on
+`author_association`, but the command then verifies the commenter's *actual* write access via the
+API (`author_association` alone includes read-only org members). Only same-repository branches are
+supported — forks are out of scope because the default token cannot push to a fork.
+
+Preconditions checked before acting: the commenter has write access, the PR is open, it is not from
+a fork, its head's status checks are green, and **it does not modify the Yarn toolchain**
+(`.yarnrc.yml` / `.yarn/releases` / `.yarn/plugins`) — the bot refuses those because `yarn install`
+would otherwise execute a PR-supplied Yarn binary or plugin under the bot token. `--skip-checks`
+overrides the status-check gate for local runs; `--dry-run` resolves without pushing.
+
+> [!IMPORTANT]
+> A push authenticated with the default `GITHUB_TOKEN` does **not** start new workflow runs, so CI
+> would not re-run on the merge commit. To make CI re-run (so the PR can be merged on fresh checks),
+> add a `LOCKFILE_BOT_TOKEN` secret — a fine-grained PAT (or a GitHub App installation token via
+> `actions/create-github-app-token`) with `contents: write` and `pull-requests: write`. The workflow
+> uses it when present and falls back to `GITHUB_TOKEN` otherwise.

--- a/xtask/cli.ts
+++ b/xtask/cli.ts
@@ -5,6 +5,7 @@ import { AttwCommand } from './commands/attw.ts';
 import { PrepareReleaseCommand } from './commands/prepare-release.ts';
 import { PrereleaseCommand } from './commands/prerelease.ts';
 import { ReleaseCommand } from './commands/release.ts';
+import { ResolveLockfileCommand } from './commands/resolve-lockfile.ts';
 
 const [, , ...args] = process.argv;
 
@@ -20,4 +21,5 @@ cli.register(PrereleaseCommand);
 cli.register(ArtifactsSpreadCommand);
 cli.register(ArtifactsMergeCommand);
 cli.register(AttwCommand);
+cli.register(ResolveLockfileCommand);
 cli.runExit(args);

--- a/xtask/commands/resolve-lockfile.ts
+++ b/xtask/commands/resolve-lockfile.ts
@@ -1,0 +1,338 @@
+import { Command, Option } from 'clipanion';
+import { execa } from 'execa';
+import * as t from 'typanion';
+import { runCommand } from '../child_process.ts';
+import { ColorModeOption, c, setColorMode } from '../console.ts';
+import { GITHUB_REPO, ROOT_DIR } from '../consts.ts';
+import { createGitHubClient, type GitHubClient } from '../github.ts';
+import {
+  classifyConflict,
+  evaluateStatusChecks,
+  LOCKFILE,
+  parseConflictedFiles,
+} from '../lockfile-merge.ts';
+
+interface GitResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** Run a git subcommand in the repo root, capturing output. Never rejects — inspect `exitCode`. */
+async function git(args: string[]): Promise<GitResult> {
+  const res = await (execa as any)('git', args, { cwd: ROOT_DIR, reject: false });
+  return {
+    exitCode: typeof res.exitCode === 'number' ? res.exitCode : 1,
+    stdout: typeof res.stdout === 'string' ? res.stdout : '',
+    stderr: typeof res.stderr === 'string' ? res.stderr : '',
+  };
+}
+
+/** Run git expecting success; throws with stderr on a non-zero exit. */
+async function gitOk(args: string[]): Promise<string> {
+  const res = await git(args);
+  if (res.exitCode !== 0) {
+    throw new Error(`git ${args.join(' ')} failed (${res.exitCode}): ${res.stderr.trim()}`);
+  }
+  return res.stdout.trim();
+}
+
+type ReactionContent = 'eyes' | 'rocket' | 'confused' | '-1';
+
+/**
+ * Auto-resolve a pull request whose only merge conflict with its base branch is `yarn.lock`.
+ *
+ * Invoked from the `resolve-lockfile` workflow when a maintainer comments the trigger command on a
+ * PR. The algorithm mirrors what a human would do by hand:
+ *
+ *   1. Verify the PR is open, same-repo (forks are out of scope), and its head's status checks are
+ *      green — i.e. it is only the conflict that blocks the merge.
+ *   2. Merge the base branch into the head locally (`--no-commit`) and look at what conflicts.
+ *   3. If `yarn.lock` is the *only* conflict, take the base branch's `yarn.lock` and run
+ *      `yarn install` to regenerate it against the merged `package.json` set, then commit the merge
+ *      and push it back to the head branch. Any other conflict aborts and asks for a human.
+ *
+ * The bot never merges the PR itself: pushing re-runs CI, and a human merges once it is green.
+ */
+export class ResolveLockfileCommand extends Command {
+  static paths = [['resolve-lockfile']];
+
+  readonly pr = Option.String('--pr', {
+    required: true,
+    description: 'Pull request number to resolve',
+    validator: t.cascade(t.isNumber(), [t.isInteger(), t.isPositive()]),
+  });
+  readonly githubToken = Option.String('--github-token', { required: false, env: 'GITHUB_TOKEN' });
+  /** The id of the triggering comment; when set, the bot reacts to it to signal progress. */
+  readonly commentId = Option.String('--comment-id', {
+    required: false,
+    env: 'COMMENT_ID',
+    validator: t.cascade(t.isNumber(), [t.isInteger()]),
+  });
+  /**
+   * The login of the user who triggered the command. When set, the bot verifies they actually have
+   * write access before acting — `author_association` (checked in the workflow) is only a coarse
+   * pre-filter and includes read-only org members/collaborators.
+   */
+  readonly commentUser = Option.String('--comment-user', { required: false, env: 'COMMENT_USER' });
+  /**
+   * Whether the push will re-trigger CI. A push authenticated with the default `GITHUB_TOKEN` does
+   * NOT start new workflow runs; the workflow sets this from whether a dedicated bot token is used,
+   * so the success comment can tell the maintainer the truth about CI re-running.
+   */
+  readonly ciWillRerun = Option.String('--ci-will-rerun', 'false', { env: 'CI_WILL_RERUN' });
+  readonly committerName = Option.String('--committer-name', 'github-actions[bot]');
+  readonly committerEmail = Option.String(
+    '--committer-email',
+    '41898282+github-actions[bot]@users.noreply.github.com'
+  );
+  /** Skip the status-check gate (for local testing / manual override). */
+  readonly skipChecks = Option.Boolean('--skip-checks', false);
+  /** Resolve and commit locally but do not push. */
+  readonly dryRun = Option.Boolean('--dry-run', false);
+  readonly colorMode = ColorModeOption;
+
+  #client!: GitHubClient;
+
+  async execute(): Promise<number> {
+    setColorMode(this.colorMode);
+    if (this.githubToken == null || this.githubToken.length === 0) {
+      console.error(c.error('a GitHub token is required (--github-token or $GITHUB_TOKEN)'));
+      return 1;
+    }
+    this.#client = createGitHubClient(this.githubToken);
+
+    await this.react('eyes');
+    try {
+      return await this.run();
+    } catch (error) {
+      // Keep the detailed error (which may include git/command stderr) in the workflow logs only,
+      // not in the public comment.
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(c.error(`resolve-lockfile failed: ${message}`));
+      await this.safeAbortMerge();
+      await this.react('-1');
+      await this.comment(
+        `❌ Failed to auto-resolve \`${LOCKFILE}\`. The merge was aborted; please resolve it manually. See the workflow run logs for details.`
+      );
+      return 1;
+    }
+  }
+
+  async run(): Promise<number> {
+    const { owner, name: repo } = GITHUB_REPO;
+
+    // Authorize the commenter by *actual* repository permission, not `author_association`: a
+    // read-only org member or triage collaborator also reports MEMBER/COLLABORATOR.
+    if (this.commentUser != null && this.commentUser.length > 0) {
+      const { data: perm } = await this.#client.rest.repos.getCollaboratorPermissionLevel({
+        owner,
+        repo,
+        username: this.commentUser,
+      });
+      // `permission` collapses to admin|write|read|none (maintain→write, triage→read).
+      if (perm.permission !== 'admin' && perm.permission !== 'write') {
+        return this.bail(`@${this.commentUser} does not have write access to this repository.`);
+      }
+    }
+
+    const pull = (await this.#client.rest.pulls.get({ owner, repo, pull_number: this.pr })).data;
+
+    if (pull.state !== 'open') {
+      return this.bail(`This PR is ${pull.state}, not open.`);
+    }
+    // Forks are out of scope: GITHUB_TOKEN cannot push to a fork's branch, and accepting
+    // fork-authored pushes is a separate security decision.
+    if (pull.head.repo == null || pull.head.repo.full_name !== `${owner}/${repo}`) {
+      return this.bail(
+        'This PR comes from a fork. Only same-repository branches are supported for now.'
+      );
+    }
+
+    const head = pull.head.ref;
+    const base = pull.base.ref;
+    const headSha = pull.head.sha;
+    console.log(`${c.info('[resolve-lockfile]')} PR #${this.pr}: ${head} ← ${base} (@${headSha})`);
+
+    if (!this.skipChecks) {
+      const checks = await this.evaluateChecks(headSha);
+      if (!checks.passed) {
+        return this.bail(`Status checks are not green yet — ${checks.reason}.`);
+      }
+    }
+
+    // Bring both branches into the local clone (the workflow checks out the default branch only).
+    await gitOk(['config', 'user.name', this.committerName]);
+    await gitOk(['config', 'user.email', this.committerEmail]);
+    await gitOk([
+      'fetch',
+      '--no-tags',
+      'origin',
+      `+refs/heads/${base}:refs/remotes/origin/${base}`,
+      `+refs/heads/${head}:refs/remotes/origin/${head}`,
+    ]);
+    await gitOk(['checkout', '-B', head, `refs/remotes/origin/${head}`]);
+
+    // Security gate: running `yarn install` executes the *checked-out* Yarn release and any local
+    // plugins (corepack honors the merged `yarnPath`; `.yarnrc.yml` declares plugins). If this PR
+    // changed the toolchain, that code would run under the bot token — so refuse and defer to a
+    // human rather than execute a PR-supplied binary/plugin.
+    const mergeBase = await gitOk(['merge-base', `refs/remotes/origin/${base}`, 'HEAD']);
+    const toolchainChanged = parseConflictedFiles(
+      await gitOk([
+        'diff',
+        '--name-only',
+        mergeBase,
+        'HEAD',
+        '--',
+        '.yarnrc.yml',
+        '.yarn/releases',
+        '.yarn/plugins',
+      ])
+    );
+    if (toolchainChanged.length > 0) {
+      const list = toolchainChanged.map(file => `- \`${file}\``).join('\n');
+      return this.bail(
+        `This PR modifies the Yarn toolchain, which the bot must not execute. Resolve it manually:\n${list}`
+      );
+    }
+
+    // Attempt the merge without committing; conflicts make this exit non-zero, which is expected.
+    await git(['merge', '--no-ff', '--no-commit', `refs/remotes/origin/${base}`]);
+    const conflicted = parseConflictedFiles(
+      await gitOk(['diff', '--name-only', '--diff-filter=U'])
+    );
+    const classification = classifyConflict(conflicted);
+
+    if (classification.type === 'none') {
+      await this.safeAbortMerge();
+      return this.bail('There is no conflict between this PR and its base branch.');
+    }
+    if (classification.type === 'other') {
+      await this.safeAbortMerge();
+      const list = classification.files.map(file => `- \`${file}\``).join('\n');
+      return this.bail(
+        `Conflicts are not limited to \`${LOCKFILE}\`, so this needs a human:\n${list}`
+      );
+    }
+
+    // lockfile-only: take the base branch's lockfile as the starting point, then regenerate it so
+    // it satisfies the merged `package.json` set.
+    console.log(`${c.info('[resolve-lockfile]')} regenerating ${LOCKFILE} …`);
+    await gitOk(['checkout', `refs/remotes/origin/${base}`, '--', LOCKFILE]);
+    const install = await runCommand('yarn', ['install', '--mode', 'update-lockfile'], {
+      cwd: ROOT_DIR,
+      prefix: `${c.dim('[yarn]')} `,
+    });
+    if (install.exitCode !== 0) {
+      throw new Error(`yarn install failed with exit code ${install.exitCode}`);
+    }
+    await gitOk(['add', '--', LOCKFILE]);
+
+    // Safety net: after resolving, no path may be left unmerged (every conflict is at stage 0).
+    const stillConflicted = parseConflictedFiles(
+      await gitOk(['diff', '--name-only', '--diff-filter=U'])
+    );
+    if (stillConflicted.length > 0) {
+      throw new Error(`unexpected unmerged paths remain: ${stillConflicted.join(', ')}`);
+    }
+
+    const message = `chore: merge ${base} into ${head} and regenerate ${LOCKFILE}`;
+    await gitOk(['commit', '--no-edit', '-m', message]);
+    const mergeSha = await gitOk(['rev-parse', 'HEAD']);
+
+    if (this.dryRun) {
+      console.log(`${c.warn('[dry-run]')} would push ${mergeSha} to ${head}`);
+      await this.comment(
+        `🧪 [dry-run] Resolved \`${LOCKFILE}\` locally (\`${mergeSha.slice(0, 9)}\`) but did not push.`
+      );
+      return 0;
+    }
+
+    await gitOk(['push', 'origin', `HEAD:refs/heads/${head}`]);
+    console.log(c.success(`pushed ${mergeSha} to ${head}`));
+    await this.react('rocket');
+    // A push made with the default GITHUB_TOKEN does not start new workflow runs, so be honest
+    // about whether CI will actually re-run on the merge commit.
+    const ciNote =
+      this.ciWillRerun === 'true'
+        ? 'CI will re-run on the new commit — merge once it is green.'
+        : '⚠️ CI will **not** re-run automatically (pushed with the default token). Re-trigger CI ' +
+          'on the new commit (e.g. push an empty commit, or close/reopen the PR) before merging.';
+    await this.comment(
+      `✅ Resolved the \`${LOCKFILE}\` conflict by merging \`${base}\` and regenerating the lockfile ` +
+        `from \`${base}\` (\`${mergeSha.slice(0, 9)}\`). ${ciNote}`
+    );
+    return 0;
+  }
+
+  /** Read the head's check-runs + commit-status rollup and decide whether they are green. */
+  private async evaluateChecks(headSha: string) {
+    const { owner, name: repo } = GITHUB_REPO;
+    const [checkRuns, combined] = await Promise.all([
+      this.#client.paginate(this.#client.rest.checks.listForRef, {
+        owner,
+        repo,
+        ref: headSha,
+        per_page: 100,
+      }),
+      this.#client.rest.repos.getCombinedStatusForRef({ owner, repo, ref: headSha }),
+    ]);
+    return evaluateStatusChecks({
+      checkRuns: checkRuns.map(run => ({
+        name: run.name,
+        status: run.status,
+        conclusion: run.conclusion,
+      })),
+      combinedStatusState: combined.data.state as 'success' | 'pending' | 'failure',
+      combinedStatusCount: combined.data.total_count,
+      // The resolver runs from `issue_comment`, not as a PR check, so it won't appear here — but
+      // guard against the name just in case the repo wires it up as a check later.
+      ignoreCheckNames: ['resolve-lockfile'],
+    });
+  }
+
+  /** Report a non-actionable situation back to the PR and exit cleanly (not an error). */
+  private async bail(reason: string): Promise<number> {
+    console.log(`${c.warn('[resolve-lockfile]')} ${reason}`);
+    await this.react('confused');
+    await this.comment(`ℹ️ Nothing to do: ${reason}`);
+    return 0;
+  }
+
+  private async safeAbortMerge(): Promise<void> {
+    // Only abort if a merge is actually in progress; ignore "no merge to abort".
+    await git(['merge', '--abort']);
+  }
+
+  private async comment(body: string): Promise<void> {
+    try {
+      await this.#client.rest.issues.createComment({
+        owner: GITHUB_REPO.owner,
+        repo: GITHUB_REPO.name,
+        issue_number: this.pr,
+        body,
+      });
+    } catch (error) {
+      console.warn(
+        c.warn(`could not post comment: ${error instanceof Error ? error.message : error}`)
+      );
+    }
+  }
+
+  private async react(content: ReactionContent): Promise<void> {
+    if (this.commentId == null) {
+      return;
+    }
+    try {
+      await this.#client.rest.reactions.createForIssueComment({
+        owner: GITHUB_REPO.owner,
+        repo: GITHUB_REPO.name,
+        comment_id: this.commentId,
+        content,
+      });
+    } catch {
+      // Reactions are cosmetic; never fail the run over them.
+    }
+  }
+}

--- a/xtask/commands/resolve-lockfile.ts
+++ b/xtask/commands/resolve-lockfile.ts
@@ -1,5 +1,7 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import { Command, Option } from 'clipanion';
-import { execa } from 'execa';
+import { type Commit, type Credential, type Index, openRepository, type Repository } from 'es-git';
 import * as t from 'typanion';
 import { runCommand } from '../child_process.ts';
 import { ColorModeOption, c, setColorMode } from '../console.ts';
@@ -8,36 +10,17 @@ import { createGitHubClient, type GitHubClient } from '../github.ts';
 import {
   classifyConflict,
   evaluateStatusChecks,
+  indexEntryStage,
   LOCKFILE,
-  parseConflictedFiles,
 } from '../lockfile-merge.ts';
 
-interface GitResult {
-  exitCode: number;
-  stdout: string;
-  stderr: string;
-}
-
-/** Run a git subcommand in the repo root, capturing output. Never rejects — inspect `exitCode`. */
-async function git(args: string[]): Promise<GitResult> {
-  const res = await (execa as any)('git', args, { cwd: ROOT_DIR, reject: false });
-  return {
-    exitCode: typeof res.exitCode === 'number' ? res.exitCode : 1,
-    stdout: typeof res.stdout === 'string' ? res.stdout : '',
-    stderr: typeof res.stderr === 'string' ? res.stderr : '',
-  };
-}
-
-/** Run git expecting success; throws with stderr on a non-zero exit. */
-async function gitOk(args: string[]): Promise<string> {
-  const res = await git(args);
-  if (res.exitCode !== 0) {
-    throw new Error(`git ${args.join(' ')} failed (${res.exitCode}): ${res.stderr.trim()}`);
-  }
-  return res.stdout.trim();
-}
-
 type ReactionContent = 'eyes' | 'rocket' | 'confused' | '-1';
+
+/**
+ * Yarn toolchain files. `yarn install` executes the checked-out Yarn release and any local plugins,
+ * so a PR that changes these could run arbitrary code under the bot token — the bot refuses those.
+ */
+const TOOLCHAIN_PATHS = ['.yarnrc.yml', '.yarn/releases', '.yarn/plugins'];
 
 /**
  * Auto-resolve a pull request whose only merge conflict with its base branch is `yarn.lock`.
@@ -47,7 +30,8 @@ type ReactionContent = 'eyes' | 'rocket' | 'confused' | '-1';
  *
  *   1. Verify the PR is open, same-repo (forks are out of scope), and its head's status checks are
  *      green — i.e. it is only the conflict that blocks the merge.
- *   2. Merge the base branch into the head locally (`--no-commit`) and look at what conflicts.
+ *   2. Merge the base branch into the head in-memory (via es-git/libgit2) and inspect the index for
+ *      what conflicts.
  *   3. If `yarn.lock` is the *only* conflict, take the base branch's `yarn.lock` and run
  *      `yarn install` to regenerate it against the merged `package.json` set, then commit the merge
  *      and push it back to the head branch. Any other conflict aborts and asks for a human.
@@ -75,12 +59,6 @@ export class ResolveLockfileCommand extends Command {
    * pre-filter and includes read-only org members/collaborators.
    */
   readonly commentUser = Option.String('--comment-user', { required: false, env: 'COMMENT_USER' });
-  /**
-   * Whether the push will re-trigger CI. A push authenticated with the default `GITHUB_TOKEN` does
-   * NOT start new workflow runs; the workflow sets this from whether a dedicated bot token is used,
-   * so the success comment can tell the maintainer the truth about CI re-running.
-   */
-  readonly ciWillRerun = Option.String('--ci-will-rerun', 'false', { env: 'CI_WILL_RERUN' });
   readonly committerName = Option.String('--committer-name', 'github-actions[bot]');
   readonly committerEmail = Option.String(
     '--committer-email',
@@ -93,6 +71,7 @@ export class ResolveLockfileCommand extends Command {
   readonly colorMode = ColorModeOption;
 
   #client!: GitHubClient;
+  #repo: Repository | null = null;
 
   async execute(): Promise<number> {
     setColorMode(this.colorMode);
@@ -110,7 +89,7 @@ export class ResolveLockfileCommand extends Command {
       // not in the public comment.
       const message = error instanceof Error ? error.message : String(error);
       console.error(c.error(`resolve-lockfile failed: ${message}`));
-      await this.safeAbortMerge();
+      this.safeAbortMerge();
       await this.react('-1');
       await this.comment(
         `❌ Failed to auto-resolve \`${LOCKFILE}\`. The merge was aborted; please resolve it manually. See the workflow run logs for details.`
@@ -161,35 +140,35 @@ export class ResolveLockfileCommand extends Command {
       }
     }
 
-    // Bring both branches into the local clone (the workflow checks out the default branch only).
-    await gitOk(['config', 'user.name', this.committerName]);
-    await gitOk(['config', 'user.email', this.committerEmail]);
-    await gitOk([
-      'fetch',
-      '--no-tags',
-      'origin',
-      `+refs/heads/${base}:refs/remotes/origin/${base}`,
-      `+refs/heads/${head}:refs/remotes/origin/${head}`,
-    ]);
-    await gitOk(['checkout', '-B', head, `refs/remotes/origin/${head}`]);
+    const token = this.githubToken;
+    if (token == null || token.length === 0) {
+      throw new Error('a GitHub token is required');
+    }
+    const credential: Credential = { type: 'Plain', username: 'x-access-token', password: token };
+    const gitRepo = await openRepository(ROOT_DIR);
+    this.#repo = gitRepo;
+    const origin = gitRepo.getRemote('origin');
 
-    // Security gate: running `yarn install` executes the *checked-out* Yarn release and any local
-    // plugins (corepack honors the merged `yarnPath`; `.yarnrc.yml` declares plugins). If this PR
-    // changed the toolchain, that code would run under the bot token — so refuse and defer to a
-    // human rather than execute a PR-supplied binary/plugin.
-    const mergeBase = await gitOk(['merge-base', `refs/remotes/origin/${base}`, 'HEAD']);
-    const toolchainChanged = parseConflictedFiles(
-      await gitOk([
-        'diff',
-        '--name-only',
-        mergeBase,
-        'HEAD',
-        '--',
-        '.yarnrc.yml',
-        '.yarn/releases',
-        '.yarn/plugins',
-      ])
+    // Bring both branches into the local clone (the workflow checks out the default branch only).
+    await origin.fetch(
+      [
+        `+refs/heads/${base}:refs/remotes/origin/${base}`,
+        `+refs/heads/${head}:refs/remotes/origin/${head}`,
+      ],
+      { fetch: { credential } }
     );
+    const headCommit = gitRepo.getCommit(gitRepo.revparseSingle(`refs/remotes/origin/${head}`));
+    const baseCommit = gitRepo.getCommit(gitRepo.revparseSingle(`refs/remotes/origin/${base}`));
+
+    // Check the PR head out into the working tree so the merge and `yarn install` see its files.
+    gitRepo.createBranch(head, headCommit, { force: true });
+    gitRepo.setHead(`refs/heads/${head}`);
+    gitRepo.checkoutHead({ force: true });
+
+    // Security gate: `yarn install` executes the checked-out Yarn release and any local plugins
+    // (corepack honors the merged `yarnPath`; `.yarnrc.yml` declares plugins). If this PR changed
+    // the toolchain, that code would run under the bot token — refuse and defer to a human.
+    const toolchainChanged = this.changedPaths(gitRepo, baseCommit, headCommit, TOOLCHAIN_PATHS);
     if (toolchainChanged.length > 0) {
       const list = toolchainChanged.map(file => `- \`${file}\``).join('\n');
       return this.bail(
@@ -197,29 +176,34 @@ export class ResolveLockfileCommand extends Command {
       );
     }
 
-    // Attempt the merge without committing; conflicts make this exit non-zero, which is expected.
-    await git(['merge', '--no-ff', '--no-commit', `refs/remotes/origin/${base}`]);
-    const conflicted = parseConflictedFiles(
-      await gitOk(['diff', '--name-only', '--diff-filter=U'])
-    );
-    const classification = classifyConflict(conflicted);
+    // Merge the base branch into HEAD; conflicts are written to the index rather than thrown.
+    gitRepo.merge([gitRepo.getAnnotatedCommit(baseCommit)]);
+    const index = gitRepo.index();
+    const classification = classifyConflict(this.conflictedPaths(index));
 
     if (classification.type === 'none') {
-      await this.safeAbortMerge();
+      gitRepo.cleanupState();
       return this.bail('There is no conflict between this PR and its base branch.');
     }
     if (classification.type === 'other') {
-      await this.safeAbortMerge();
+      gitRepo.cleanupState();
       const list = classification.files.map(file => `- \`${file}\``).join('\n');
       return this.bail(
         `Conflicts are not limited to \`${LOCKFILE}\`, so this needs a human:\n${list}`
       );
     }
 
-    // lockfile-only: take the base branch's lockfile as the starting point, then regenerate it so
+    // lockfile-only: write the base branch's lockfile as the starting point, then regenerate it so
     // it satisfies the merged `package.json` set.
     console.log(`${c.info('[resolve-lockfile]')} regenerating ${LOCKFILE} …`);
-    await gitOk(['checkout', `refs/remotes/origin/${base}`, '--', LOCKFILE]);
+    const baseLock = baseCommit.tree().getPath(LOCKFILE);
+    if (baseLock == null) {
+      throw new Error(`${LOCKFILE} does not exist on ${base}`);
+    }
+    await fs.writeFile(
+      path.join(ROOT_DIR, LOCKFILE),
+      baseLock.toObject(gitRepo).peelToBlob().content()
+    );
     const install = await runCommand('yarn', ['install', '--mode', 'update-lockfile'], {
       cwd: ROOT_DIR,
       prefix: `${c.dim('[yarn]')} `,
@@ -227,19 +211,26 @@ export class ResolveLockfileCommand extends Command {
     if (install.exitCode !== 0) {
       throw new Error(`yarn install failed with exit code ${install.exitCode}`);
     }
-    await gitOk(['add', '--', LOCKFILE]);
 
-    // Safety net: after resolving, no path may be left unmerged (every conflict is at stage 0).
-    const stillConflicted = parseConflictedFiles(
-      await gitOk(['diff', '--name-only', '--diff-filter=U'])
-    );
-    if (stillConflicted.length > 0) {
-      throw new Error(`unexpected unmerged paths remain: ${stillConflicted.join(', ')}`);
+    // Stage the regenerated lockfile (clears its conflict) and build the merge commit from the index.
+    index.addPath(LOCKFILE);
+    index.write();
+    if (index.hasConflicts()) {
+      throw new Error('conflicts remain after regenerating the lockfile');
     }
-
-    const message = `chore: merge ${base} into ${head} and regenerate ${LOCKFILE}`;
-    await gitOk(['commit', '--no-edit', '-m', message]);
-    const mergeSha = await gitOk(['rev-parse', 'HEAD']);
+    const tree = gitRepo.getTree(index.writeTree());
+    const signature = { name: this.committerName, email: this.committerEmail };
+    const mergeSha = gitRepo.commit(
+      tree,
+      `chore: merge ${base} into ${head} and regenerate ${LOCKFILE}`,
+      {
+        updateRef: `refs/heads/${head}`,
+        author: signature,
+        committer: signature,
+        parents: [headCommit.id(), baseCommit.id()],
+      }
+    );
+    gitRepo.cleanupState();
 
     if (this.dryRun) {
       console.log(`${c.warn('[dry-run]')} would push ${mergeSha} to ${head}`);
@@ -249,21 +240,41 @@ export class ResolveLockfileCommand extends Command {
       return 0;
     }
 
-    await gitOk(['push', 'origin', `HEAD:refs/heads/${head}`]);
+    await origin.push([`refs/heads/${head}:refs/heads/${head}`], { credential });
     console.log(c.success(`pushed ${mergeSha} to ${head}`));
     await this.react('rocket');
-    // A push made with the default GITHUB_TOKEN does not start new workflow runs, so be honest
-    // about whether CI will actually re-run on the merge commit.
-    const ciNote =
-      this.ciWillRerun === 'true'
-        ? 'CI will re-run on the new commit — merge once it is green.'
-        : '⚠️ CI will **not** re-run automatically (pushed with the default token). Re-trigger CI ' +
-          'on the new commit (e.g. push an empty commit, or close/reopen the PR) before merging.';
     await this.comment(
       `✅ Resolved the \`${LOCKFILE}\` conflict by merging \`${base}\` and regenerating the lockfile ` +
-        `from \`${base}\` (\`${mergeSha.slice(0, 9)}\`). ${ciNote}`
+        `from \`${base}\` (\`${mergeSha.slice(0, 9)}\`).`
     );
     return 0;
+  }
+
+  /** Distinct paths left in conflict (index stage > 0) after a merge. */
+  private conflictedPaths(index: Index): string[] {
+    const paths = new Set<string>();
+    const entries = index.entries();
+    for (let next = entries.next(); next.done !== true; next = entries.next()) {
+      if (indexEntryStage(next.value.flags) !== 0) {
+        paths.add(next.value.path.toString('utf8'));
+      }
+    }
+    return [...paths];
+  }
+
+  /** Paths under `pathspecs` that `to` changed relative to its merge-base with `from`. */
+  private changedPaths(repo: Repository, from: Commit, to: Commit, pathspecs: string[]): string[] {
+    const mergeBase = repo.getCommit(repo.getMergeBase(from.id(), to.id()));
+    const diff = repo.diffTreeToTree(mergeBase.tree(), to.tree(), { pathspecs });
+    const changed: string[] = [];
+    const deltas = diff.deltas();
+    for (let next = deltas.next(); next.done !== true; next = deltas.next()) {
+      const file = next.value.newFile().path() ?? next.value.oldFile().path();
+      if (file != null) {
+        changed.push(file);
+      }
+    }
+    return changed;
   }
 
   /** Read the head's check-runs + commit-status rollup and decide whether they are green. */
@@ -300,9 +311,13 @@ export class ResolveLockfileCommand extends Command {
     return 0;
   }
 
-  private async safeAbortMerge(): Promise<void> {
-    // Only abort if a merge is actually in progress; ignore "no merge to abort".
-    await git(['merge', '--abort']);
+  private safeAbortMerge(): void {
+    // Clear any in-progress merge state; ignore if no merge is in progress or the repo isn't open.
+    try {
+      this.#repo?.cleanupState();
+    } catch {
+      // nothing to clean up
+    }
   }
 
   private async comment(body: string): Promise<void> {

--- a/xtask/lockfile-merge.spec.ts
+++ b/xtask/lockfile-merge.spec.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyConflict,
+  evaluateStatusChecks,
+  LOCKFILE,
+  parseConflictedFiles,
+} from './lockfile-merge.ts';
+
+describe('classifyConflict', () => {
+  it('returns "none" when nothing conflicts', () => {
+    expect(classifyConflict([])).toEqual({ type: 'none' });
+    expect(classifyConflict(['', '  '])).toEqual({ type: 'none' });
+  });
+
+  it('returns "lockfile-only" when yarn.lock is the sole conflict', () => {
+    expect(classifyConflict([LOCKFILE])).toEqual({ type: 'lockfile-only' });
+    expect(classifyConflict([' yarn.lock '])).toEqual({ type: 'lockfile-only' });
+  });
+
+  it('returns "other" when a non-lockfile path conflicts', () => {
+    expect(classifyConflict(['package.json'])).toEqual({
+      type: 'other',
+      files: ['package.json'],
+    });
+    expect(classifyConflict(['yarn.lock', 'packages/cli/src/index.ts'])).toEqual({
+      type: 'other',
+      files: ['yarn.lock', 'packages/cli/src/index.ts'],
+    });
+  });
+});
+
+describe('parseConflictedFiles', () => {
+  it('splits, trims and drops blank lines', () => {
+    expect(parseConflictedFiles('yarn.lock\npackage.json\n')).toEqual([
+      'yarn.lock',
+      'package.json',
+    ]);
+    expect(parseConflictedFiles('')).toEqual([]);
+  });
+});
+
+describe('evaluateStatusChecks', () => {
+  const ok = { combinedStatusState: 'success' as const, combinedStatusCount: 0 };
+
+  it('passes when every check is success/neutral/skipped and no failing commit status', () => {
+    expect(
+      evaluateStatusChecks({
+        ...ok,
+        checkRuns: [
+          { name: 'ci', status: 'completed', conclusion: 'success' },
+          { name: 'attw', status: 'completed', conclusion: 'skipped' },
+          { name: 'flaky', status: 'completed', conclusion: 'neutral' },
+        ],
+      })
+    ).toEqual({ passed: true });
+  });
+
+  it('blocks while a check is still running', () => {
+    const result = evaluateStatusChecks({
+      ...ok,
+      checkRuns: [{ name: 'test', status: 'in_progress', conclusion: null }],
+    });
+    expect(result.passed).toBe(false);
+  });
+
+  it('blocks on a failing check', () => {
+    const result = evaluateStatusChecks({
+      ...ok,
+      checkRuns: [{ name: 'test', status: 'completed', conclusion: 'failure' }],
+    });
+    expect(result.passed).toBe(false);
+  });
+
+  it('blocks on a failing commit status even when check-runs are green', () => {
+    const result = evaluateStatusChecks({
+      checkRuns: [{ name: 'ci', status: 'completed', conclusion: 'success' }],
+      combinedStatusState: 'failure',
+      combinedStatusCount: 1,
+    });
+    expect(result.passed).toBe(false);
+  });
+
+  it('ignores the named checks (e.g. the bot itself) but still gates on the rest', () => {
+    expect(
+      evaluateStatusChecks({
+        ...ok,
+        checkRuns: [
+          { name: 'resolve-lockfile', status: 'in_progress', conclusion: null },
+          { name: 'ci', status: 'completed', conclusion: 'success' },
+        ],
+        ignoreCheckNames: ['resolve-lockfile'],
+      })
+    ).toEqual({ passed: true });
+  });
+
+  it('does not green-light when no checks have reported yet', () => {
+    expect(evaluateStatusChecks({ ...ok, checkRuns: [] }).passed).toBe(false);
+    // a lone ignored check counts as nothing reported
+    expect(
+      evaluateStatusChecks({
+        ...ok,
+        checkRuns: [{ name: 'resolve-lockfile', status: 'in_progress', conclusion: null }],
+        ignoreCheckNames: ['resolve-lockfile'],
+      }).passed
+    ).toBe(false);
+  });
+
+  it('blocks on a pending commit-status rollup', () => {
+    expect(
+      evaluateStatusChecks({
+        checkRuns: [{ name: 'ci', status: 'completed', conclusion: 'success' }],
+        combinedStatusState: 'pending',
+        combinedStatusCount: 2,
+      }).passed
+    ).toBe(false);
+  });
+
+  it('ignores the commit-status state when there are zero statuses', () => {
+    // total_count 0 means the legacy status API is unused; a green check-run alone passes.
+    expect(
+      evaluateStatusChecks({
+        checkRuns: [{ name: 'ci', status: 'completed', conclusion: 'success' }],
+        combinedStatusState: 'pending',
+        combinedStatusCount: 0,
+      })
+    ).toEqual({ passed: true });
+  });
+});

--- a/xtask/lockfile-merge.spec.ts
+++ b/xtask/lockfile-merge.spec.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   classifyConflict,
   evaluateStatusChecks,
+  indexEntryStage,
   LOCKFILE,
-  parseConflictedFiles,
 } from './lockfile-merge.ts';
 
 describe('classifyConflict', () => {
@@ -29,13 +29,15 @@ describe('classifyConflict', () => {
   });
 });
 
-describe('parseConflictedFiles', () => {
-  it('splits, trims and drops blank lines', () => {
-    expect(parseConflictedFiles('yarn.lock\npackage.json\n')).toEqual([
-      'yarn.lock',
-      'package.json',
-    ]);
-    expect(parseConflictedFiles('')).toEqual([]);
+describe('indexEntryStage', () => {
+  it('decodes the conflict stage from libgit2 index flags', () => {
+    expect(indexEntryStage(0)).toBe(0); // normally staged
+    expect(indexEntryStage(0x1000)).toBe(1); // ancestor
+    expect(indexEntryStage(0x2000)).toBe(2); // ours
+    expect(indexEntryStage(0x3000)).toBe(3); // theirs
+    // other flag bits (e.g. name length / extended) must not leak into the stage
+    expect(indexEntryStage(0x2000 | 0x0fff)).toBe(2);
+    expect(indexEntryStage(0x8000 | 0x1000)).toBe(1);
   });
 });
 

--- a/xtask/lockfile-merge.ts
+++ b/xtask/lockfile-merge.ts
@@ -1,0 +1,98 @@
+/** The lockfile this bot knows how to auto-resolve. */
+export const LOCKFILE = 'yarn.lock';
+
+/** Slash command that triggers the resolver from a PR comment. */
+export const TRIGGER_COMMAND = '/merge-lockfile';
+
+/**
+ * Outcome of classifying the files left unmerged after attempting to merge the base branch into a
+ * PR head branch.
+ *
+ * - `none` — the merge had no conflicts (base already merges cleanly); nothing to do.
+ * - `lockfile-only` — the only conflict is `yarn.lock`; safe to auto-resolve by regenerating it.
+ * - `other` — at least one non-lockfile path conflicts; a human has to resolve it.
+ */
+export type ConflictClassification =
+  | { type: 'none' }
+  | { type: 'lockfile-only' }
+  | { type: 'other'; files: string[] };
+
+/**
+ * Classify the set of unmerged (conflicted) paths reported by `git diff --diff-filter=U`.
+ *
+ * The bot only auto-resolves when `yarn.lock` is the *sole* conflict: a conflict anywhere else
+ * means the merge carries real source changes that must be reviewed by a human, so we bail out
+ * rather than guess.
+ */
+export function classifyConflict(conflictedFiles: readonly string[]): ConflictClassification {
+  const files = conflictedFiles.map(file => file.trim()).filter(file => file.length > 0);
+  if (files.length === 0) {
+    return { type: 'none' };
+  }
+  if (files.length === 1 && files[0] === LOCKFILE) {
+    return { type: 'lockfile-only' };
+  }
+  return { type: 'other', files };
+}
+
+/** Parse `git diff --name-only --diff-filter=U` stdout into a list of paths. */
+export function parseConflictedFiles(stdout: string): string[] {
+  return stdout
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length > 0);
+}
+
+export interface CheckRunLike {
+  name: string;
+  /** GitHub check-run status, e.g. `queued` | `in_progress` | `completed`. */
+  status: string;
+  /** GitHub check-run conclusion, e.g. `success` | `failure` | `neutral` | `skipped`, or null. */
+  conclusion: string | null;
+}
+
+/** A check-run conclusion that does not block merging. */
+const PASSING_CONCLUSIONS = new Set(['success', 'neutral', 'skipped']);
+
+export type StatusChecksResult = { passed: true } | { passed: false; reason: string };
+
+/**
+ * Decide whether a PR head's status checks are "green enough" to act on.
+ *
+ * A check blocks if it is still running (`status !== 'completed'`) or completed with a conclusion
+ * outside {success, neutral, skipped}. `combinedStatusState` is the legacy commit-status rollup
+ * (`success` | `pending` | `failure`); it only blocks when there is at least one such status.
+ *
+ * `ignoreCheckNames` lets the caller exclude this bot's own check-run (if it ever surfaces as one)
+ * so the resolver never waits on itself.
+ */
+export function evaluateStatusChecks(args: {
+  checkRuns: readonly CheckRunLike[];
+  combinedStatusState: 'success' | 'pending' | 'failure';
+  combinedStatusCount: number;
+  ignoreCheckNames?: readonly string[];
+}): StatusChecksResult {
+  const ignored = new Set(args.ignoreCheckNames ?? []);
+  let consideredCount = 0;
+  for (const run of args.checkRuns) {
+    if (ignored.has(run.name)) {
+      continue;
+    }
+    consideredCount += 1;
+    if (run.status !== 'completed') {
+      return { passed: false, reason: `check "${run.name}" is still ${run.status}` };
+    }
+    if (!PASSING_CONCLUSIONS.has(run.conclusion ?? '')) {
+      return { passed: false, reason: `check "${run.name}" concluded ${run.conclusion ?? 'null'}` };
+    }
+  }
+  if (args.combinedStatusCount > 0 && args.combinedStatusState !== 'success') {
+    return { passed: false, reason: `commit status is ${args.combinedStatusState}` };
+  }
+  // Distinguish "no checks required" from "CI hasn't reported yet": with nothing to gate on, refuse
+  // rather than green-light a PR whose checks simply have not started.
+  if (consideredCount === 0 && args.combinedStatusCount === 0) {
+    return { passed: false, reason: 'no status checks have reported yet' };
+  }
+  return { passed: true };
+}

--- a/xtask/lockfile-merge.ts
+++ b/xtask/lockfile-merge.ts
@@ -35,12 +35,13 @@ export function classifyConflict(conflictedFiles: readonly string[]): ConflictCl
   return { type: 'other', files };
 }
 
-/** Parse `git diff --name-only --diff-filter=U` stdout into a list of paths. */
-export function parseConflictedFiles(stdout: string): string[] {
-  return stdout
-    .split('\n')
-    .map(line => line.trim())
-    .filter(line => line.length > 0);
+/**
+ * Decode the merge stage from a libgit2 index entry's `flags`. Stage 0 is a normally-staged file;
+ * stages 1/2/3 (ancestor/ours/theirs) mark a path still in conflict. The stage lives in bits 12-13
+ * of `flags` (mask `0x3000`).
+ */
+export function indexEntryStage(flags: number): number {
+  return (flags >> 12) & 0x3;
 }
 
 export interface CheckRunLike {


### PR DESCRIPTION
## Summary

A comment-triggered bot that auto-resolves a PR whose **only** merge conflict with its base branch is `yarn.lock` — the routine case when several PRs are open and each regenerates the shared root lockfile while their `package.json` changes don't actually overlap.

**Trigger:** a maintainer comments `/merge-lockfile` on the PR.

**What it does** (`xtask resolve-lockfile`, driven by the `resolve-lockfile` workflow):
1. Verify the commenter has write access, the PR is open, it's not from a fork, its head's checks are green, and it doesn't touch the Yarn toolchain.
2. Merge the base branch into the PR head locally (`git merge --no-ff --no-commit`).
3. **Only if `yarn.lock` is the sole conflict**, take the base branch's `yarn.lock`, run `yarn install --mode update-lockfile` to regenerate it against the merged `package.json` set, commit the merge, and push it back to the PR branch.
4. Any other conflict → abort and ask for a human.

The bot **never merges the PR** — pushing re-runs CI and a human merges once it's green.

### Decisions (agreed up front)
| Choice | Decision |
|---|---|
| Trigger | PR comment slash-command `/merge-lockfile` |
| After resolve | Resolve & push only (human merges) |
| Scope | Same-repository branches only (forks excluded — the default token can't push to a fork) |

## Files
- `xtask/commands/resolve-lockfile.ts` — the command (Octokit reads, git/yarn ops, push, PR comment + reactions).
- `xtask/lockfile-merge.ts` + `xtask/lockfile-merge.spec.ts` — pure helpers (conflict classification, status-check evaluation) with unit tests.
- `.github/workflows/resolve-lockfile.yaml` — `issue_comment` workflow with the permission gate and token handling.
- `xtask/cli.ts`, `xtask/README.md` — registration + docs.

## Security hardening (from an adversarial review)
- **Real write-access check.** The command verifies the commenter's actual permission via `GET /collaborators/{user}/permission` (admin/write). `author_association` — checked in the workflow — is only a coarse pre-filter that also matches read-only org members/collaborators.
- **Toolchain refusal (RCE guard).** `yarn install` executes the *checked-out* Yarn release and any local plugins. The bot refuses any PR that changed `.yarnrc.yml` / `.yarn/releases` / `.yarn/plugins`, so a PR can't get arbitrary code execution under the bot token. (`--mode update-lockfile` already skips npm lifecycle scripts.)
- **No premature green-light.** `evaluateStatusChecks` treats "zero checks reported" as *not passed*, so the bot won't act before CI starts.
- **Tighter trigger + no leakage.** Command must be at the *start* of the comment (`startsWith`); failure comments no longer echo raw command stderr (details stay in the workflow logs).
- **Honest CI note.** A push made with the default `GITHUB_TOKEN` does **not** re-trigger workflows. The success comment says so unless a dedicated bot token is configured.

> [!IMPORTANT]
> To make CI actually re-run on the merge commit (so the PR can be merged on fresh checks), add a **`LOCKFILE_BOT_TOKEN`** secret — a fine-grained PAT or a GitHub App installation token with `contents: write` + `pull-requests: write`. The workflow uses it when present and falls back to `GITHUB_TOKEN` (push works, but CI won't re-run) otherwise.

## Verification
- ✅ `xtask` typecheck, full-repo `biome check` (289 files), 12 unit tests pass (also under the workspace vitest config CI uses).
- ✅ Git mechanics simulated in scratch repos: lockfile-only conflict → correct 2-parent merge with both sides' changes; non-lockfile conflict → bail; toolchain-swap PR → detected and refused; missing pathspec → no error.

## Follow-up (maintainer)
Create the `LOCKFILE_BOT_TOKEN` secret (PAT or GitHub App) so CI re-runs after the bot pushes. Without it the bot still resolves and pushes, but CI must be re-triggered manually before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/webview-bundle/webview-bundle/pull/194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

