### PR TITLE
fix(core): retry manifest read on Windows transient errors during concurrent rename

### DIFF
--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -51,7 +51,7 @@ tokio      = { workspace = true, features = ["full"] }
 [features]
 _reqwest = ["dep:reqwest"]
 _serde = ["dep:serde", "dep:serde_json", "dep:serde_repr"]
-async = ["dep:tokio", "tokio/io-util", "tokio/rt", "tokio/rt-multi-thread", "tokio/fs", "tokio/sync"]
+async = ["dep:tokio", "tokio/io-util", "tokio/rt", "tokio/rt-multi-thread", "tokio/fs", "tokio/sync", "tokio/time"]
 full = [
   "serde",
   "async",

--- a/packages/core/src/source/manifest.rs
+++ b/packages/core/src/source/manifest.rs
@@ -185,12 +185,28 @@ where
         if !tokio::fs::try_exists(&self.filepath).await? {
           return Ok::<RwLock<BundleManifestData>, crate::Error>(Default::default());
         }
-        let raw = tokio::fs::read(&self.filepath).await?;
+        let raw = read_with_win_retry(&self.filepath).await?;
         let data: BundleManifestData = serde_json::from_slice(&raw)?;
         Ok::<RwLock<BundleManifestData>, crate::Error>(RwLock::new(data))
       })
       .await?;
     Ok(data)
+  }
+}
+
+// Windows briefly returns ACCESS_DENIED (5) / SHARING_VIOLATION (32) when reading a file a concurrent save is renaming into place; retry those.
+async fn read_with_win_retry(path: &Path) -> std::io::Result<Vec<u8>> {
+  let mut attempts = 0;
+  loop {
+    match tokio::fs::read(path).await {
+      Err(e)
+        if attempts < 20 && cfg!(windows) && matches!(e.raw_os_error(), Some(5) | Some(32)) =>
+      {
+        attempts += 1;
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+      }
+      result => return result,
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

On Windows a fresh source reading the bundle manifest while a concurrent `save()` renames it into place can fail with `ERROR_ACCESS_DENIED`/`SHARING_VIOLATION`; the manifest read now briefly retries those (Windows-only), fixing the flaky `concurrent_reload_no_partial_manifest` failure on the `aarch64-pc-windows-msvc` runner.

## Test Plan

`cargo test -p wvb --features full` (incl. `--test concurrency`) passes; the retry is `cfg!(windows)`-gated so POSIX behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01USdgQwPgzYcynb77WVvJug


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/webview-bundle/webview-bundle/pull/197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

