### PR TITLE
fix(xtask): cargo toml formatting breaks releasing

### DIFF
--- a/xtask/cargo-toml.spec.ts
+++ b/xtask/cargo-toml.spec.ts
@@ -1,0 +1,55 @@
+import * as TOML from '@ltd/j-toml';
+import { describe, expect, it } from 'vitest';
+import { editCargoTomlVersion, formatCargoToml, parseCargoToml } from './cargo-toml.ts';
+import { Version } from './version.ts';
+
+function bump(raw: string, version: string): string {
+  const toml = parseCargoToml(raw);
+  editCargoTomlVersion(toml, Version.parse(version));
+  return formatCargoToml(toml);
+}
+
+describe('formatCargoToml', () => {
+  it('bumps the package version', () => {
+    const out = bump('[package]\nname = "demo"\nversion = "0.1.0"\n', '0.1.0-next.abc1234');
+    expect(out).toContain('version = "0.1.0-next.abc1234"');
+    expect(() => TOML.parse(out)).not.toThrow();
+  });
+
+  it('keeps a literal-string table key that embeds a double quote valid', () => {
+    // Regression: the naive `'` -> `"` replacement turned
+    // `[target.'cfg(target_os = "android")'.dependencies]` into invalid TOML
+    // (`unclosed table, expected ]`), failing `cargo publish` in the release job.
+    const raw = [
+      '[package]',
+      'name = "demo"',
+      'version = "0.1.0"',
+      '',
+      '[target.\'cfg(target_os = "android")\'.dependencies]',
+      'serde_json = { workspace = true }',
+      '',
+      "[target.'cfg(any())'.dependencies]",
+      'alloc-stdlib = "=0.2.2"',
+      '',
+    ].join('\n');
+
+    const out = bump(raw, '0.1.0-next.abc1234');
+
+    // The literal key with an embedded `"` must stay a literal (single-quoted) string.
+    expect(out).toContain('[target.\'cfg(target_os = "android")\'.dependencies]');
+    // A literal key with no embedded `"` is normalized to a basic (double-quoted) string.
+    expect(out).toContain('[target."cfg(any())".dependencies]');
+    // Above all, the result must be parseable TOML.
+    const reparsed = parseCargoToml(out) as unknown as { target: Record<string, unknown> };
+    expect(Object.keys(reparsed.target)).toContain('cfg(target_os = "android")');
+  });
+
+  it('does not touch apostrophes inside basic strings', () => {
+    const out = bump(
+      '[package]\nname = "demo"\nversion = "0.1.0"\ndescription = "it\'s fine"\n',
+      '0.1.0-next.abc1234'
+    );
+    expect(out).toContain('description = "it\'s fine"');
+    expect(() => TOML.parse(out)).not.toThrow();
+  });
+});

--- a/xtask/cargo-toml.ts
+++ b/xtask/cargo-toml.ts
@@ -80,7 +80,56 @@ export function formatCargoToml(toml: CargoToml): string {
     const prevLine = content[i - 1];
     return !(prevLine?.startsWith('[') === true && line === '');
   });
-  return taplo
-    .format(content.join('\n'), { options: taploConfig.formatting })
-    .replaceAll(/'/g, '"');
+  const formatted = taplo.format(content.join('\n'), { options: taploConfig.formatting });
+  return preferDoubleQuotes(formatted);
+}
+
+/**
+ * j-toml renders every string as a single-quoted TOML *literal* string, but this repo's
+ * Cargo.toml style (double-quoted *basic* strings) is what `taplo` and the source files use.
+ * A blanket `'` → `"` replacement is unsafe: a literal string whose content contains a `"` —
+ * e.g. the `[target.'cfg(target_os = "android")'.dependencies]` key — becomes invalid TOML
+ * (`unclosed table, expected ]`) once its delimiters flip to double quotes.
+ *
+ * This walks the document token by token: basic strings are copied verbatim (so apostrophes
+ * inside them are never touched), and a literal string is converted to a basic string only when
+ * its content has no `"` or `\` that would require escaping. Otherwise it is left as a literal.
+ */
+function preferDoubleQuotes(toml: string): string {
+  let out = '';
+  for (let i = 0; i < toml.length; ) {
+    const ch = toml[i];
+    if (ch === '"') {
+      // Basic string: copy through the matching close quote, honoring backslash escapes.
+      out += ch;
+      i++;
+      while (i < toml.length) {
+        const c = toml[i];
+        out += c;
+        i++;
+        if (c === '\\' && i < toml.length) {
+          out += toml[i];
+          i++;
+        } else if (c === '"') {
+          break;
+        }
+      }
+    } else if (ch === "'") {
+      // Literal string: content runs to the next single quote on the same line.
+      const end = toml.indexOf("'", i + 1);
+      const newline = toml.indexOf('\n', i + 1);
+      if (end !== -1 && (newline === -1 || end < newline)) {
+        const inner = toml.slice(i + 1, end);
+        out += inner.includes('"') || inner.includes('\\') ? `'${inner}'` : `"${inner}"`;
+        i = end + 1;
+      } else {
+        out += ch;
+        i++;
+      }
+    } else {
+      out += ch;
+      i++;
+    }
+  }
+  return out;
 }


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/webview-bundle/webview-bundle/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

