### PR TITLE
fix(ffi): align e2e testTimeout with in-test waits

### DIFF
--- a/packages/ffi/e2e/vitest.e2e-ffi.config.ts
+++ b/packages/ffi/e2e/vitest.e2e-ffi.config.ts
@@ -6,7 +6,10 @@ const config: ViteUserConfig = defineConfig({
     include: ['**/*.spec.ts'],
     fileParallelism: false,
     pool: 'forks',
-    testTimeout: 30_000,
+    // Must exceed the specs' in-test wait budgets (apple.spec.ts waits up to 120s for the run
+    // button + 180s for the suite to finish), or vitest kills the test before those waits get to
+    // time out with their own, more specific error messages.
+    testTimeout: 360_000,
     hookTimeout: 1_800_000,
   },
 });


### PR DESCRIPTION
## Summary

The ffi e2e jobs fail intermittently with `Test timed out in 30000ms` (e.g. [this run](https://github.com/webview-bundle/webview-bundle/actions/runs/28831052113/job/85504849468#step:14:1)).

The specs are written to wait long for the on-device native suite — android waits up to 30s for the run button + 120s for completion, apple up to 120s + 180s — with specific `timeoutMsg`s for each phase. But vitest's `testTimeout: 30_000` preempts those waits, so whenever the emulator is slow the test is killed at 30s; on fast runs it happens to finish in time, hence the flakiness.

Raise `testTimeout` to 360s (above the largest in-test budget, apple's 300s) so the inner waits govern and report their own errors. Genuine hangs are still bounded per test.

## Test Plan

- The change is a vitest config constant; the affected path is exercised by the `ci-ffi` workflow on this PR (`ffi-test-android` runs the same `Run e2e test` step that flaked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZPRPXvG9gvJLFMje9pz37

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/webview-bundle/webview-bundle/pull/208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

