### PR TITLE
ci: free runner disk space in ffi android job

### DIFF
--- a/.github/workflows/ci-ffi.yaml
+++ b/.github/workflows/ci-ffi.yaml
@@ -32,10 +32,7 @@ jobs:
     if: needs.detect-changes.outputs.ffi == 'true'
     runs-on: ubuntu-latest
     steps:
-      # The NDK build, cargo target dir, own Android SDK (install-sdk puts it in ~/android-sdk)
-      # and the emulator system image only fit on the runner when the preinstalled toolchains
-      # this job never uses are removed first; without this the emulator-runner step dies
-      # intermittently with "No space left on device".
+      # Drop preinstalled toolchains this job never uses; otherwise the emulator install dies intermittently with "No space left on device".
       - name: Free disk space
         run: |
           df -h /

--- a/.github/workflows/ci-ffi.yaml
+++ b/.github/workflows/ci-ffi.yaml
@@ -32,6 +32,17 @@ jobs:
     if: needs.detect-changes.outputs.ffi == 'true'
     runs-on: ubuntu-latest
     steps:
+      # The NDK build, cargo target dir, own Android SDK (install-sdk puts it in ~/android-sdk)
+      # and the emulator system image only fit on the runner when the preinstalled toolchains
+      # this job never uses are removed first; without this the emulator-runner step dies
+      # intermittently with "No space left on device".
+      - name: Free disk space
+        run: |
+          df -h /
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /usr/local/.ghcup /usr/share/swift /opt/hostedtoolcache/CodeQL &
+          sudo docker image prune --all --force > /dev/null 2>&1 &
+          wait
+          df -h /
       - name: Git checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # 6.0.1
       - name: Setup Rust


### PR DESCRIPTION
## Summary

`ffi-test-android` fails intermittently with `No space left on device` while the emulator-runner step installs the system image ([example run](https://github.com/webview-bundle/webview-bundle/actions/runs/28844276958/job/85544594485)) — a different flake from the vitest timeout fixed in #208.

The job installs its own Android SDK (to `~/android-sdk`) and NDK, and builds Rust for Android, on a runner whose preinstalled toolchains already fill most of the disk — including a second, unused Android SDK at `/usr/local/lib/android` (~10GB), plus .NET, Haskell, Swift, CodeQL, and preloaded docker images. Whether the job fits depends on cache state, hence the intermittence.

Add a `Free disk space` step at job start that removes those unused toolchains (~20GB+), with `df -h` before/after logged for future debugging.

## Test Plan

- The workflow file itself is in the `ci-ffi` paths filter, so this PR runs the modified job; the `df -h` output shows the reclaimed space and the e2e step exercises the emulator install that previously hit the limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZPRPXvG9gvJLFMje9pz37

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/webview-bundle/webview-bundle/pull/209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

