### PR TITLE
feat(xtask): support exact version bumping

### DIFF
--- a/.github/workflows/ci-xtask.yaml
+++ b/.github/workflows/ci-xtask.yaml
@@ -1,0 +1,38 @@
+name: ci-xtask
+on:
+  pull_request:
+concurrency:
+  group: ci-xtask-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+env:
+  LEFTHOOK: 0
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    outputs:
+      xtask: ${{ steps.filter.outputs.xtask }}
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # 6.0.1
+      - name: Filter changed paths
+        id: filter
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        with:
+          filters: |
+            xtask:
+              - 'xtask/**/*'
+              - '.github/workflows/ci-xtask.yaml'
+              - '.github/actions/**'
+  ci:
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.xtask == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # 6.0.1
+      - name: Setup Node.js
+        uses: ./.github/actions/node-setup
+      - run: yarn workspaces focus xtask
+      - run: yarn workspace xtask run typecheck
+      - run: yarn workspace xtask run test

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,10 @@
     "resolveJsonModule": true,
     "declaration": true,
     "isolatedDeclarations": true
-  }
+  },
+  "references": [
+    {
+      "path": "./tsconfig.xtask-config.json"
+    }
+  ]
 }

--- a/tsconfig.xtask-config.json
+++ b/tsconfig.xtask-config.json
@@ -1,9 +1,9 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "rewriteRelativeImportExtensions": true,
     "allowImportingTsExtensions": true,
     "isolatedDeclarations": false
   },
-  "include": ["**/*.ts"]
+  "include": ["./xtask.config.ts"]
 }

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -2,11 +2,7 @@ import { defineConfig, type UserWorkspaceConfig } from 'vitest/config';
 
 const config: UserWorkspaceConfig = defineConfig({
   test: {
-    projects: [
-      'packages/*/vitest.config.ts',
-      'packages/remote/*/vitest.config.ts',
-      'xtask/vitest.config.ts',
-    ],
+    projects: ['packages/*/vitest.config.ts', 'packages/remote/*/vitest.config.ts'],
   },
 });
 

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -25,6 +25,13 @@ picks up the new version. Contributors are not required to follow any commit con
    since its last tag (`<name>/<version>`), lets you pick which go in the changelog and the
    version bump, propagates through the dependency graph, then commits the bumps + changelogs to a
    content-addressed `release/<hash>` branch and opens (or updates) a PR via the `gh` CLI.
+
+   The bump is `patch`/`minor`/`major` — each shown with the version it lands on — or **`exact
+   version`**, which asks for the next version outright. Use it when no rule expresses the intent,
+   typically to land several packages on one shared version. The version has to be ahead of the
+   package's current one (`release` only publishes what the merge commit *raised*), and it applies
+   to every manifest the package owns, so a package whose manifests have drifted apart (e.g. the
+   napi platform packages) is realigned on the way.
 2. Merging that PR is the trigger: on the base branch the CI runs `just xtask release`, which
    publishes every package bumped by the merge commit, tags the merge commit, pushes the tags, and
    creates GitHub releases (uploading each package's configured assets). Every step skips work

--- a/xtask/cargo-toml.spec.ts
+++ b/xtask/cargo-toml.spec.ts
@@ -4,25 +4,49 @@ import { editCargoTomlVersion, formatCargoToml, parseCargoToml } from './cargo-t
 import { Version } from './version.ts';
 
 function bump(raw: string, version: string): string {
-  const toml = parseCargoToml(raw);
-  editCargoTomlVersion(toml, Version.parse(version));
-  return formatCargoToml(toml);
+  return formatCargoToml(editCargoTomlVersion(raw, Version.parse(version)));
 }
 
-describe('formatCargoToml', () => {
+function bumpDep(raw: string, dep: string, version: string): string {
+  return editCargoTomlVersion(raw, Version.parse(version), dep);
+}
+
+describe('editCargoTomlVersion', () => {
   it('bumps the package version', () => {
     const out = bump('[package]\nname = "demo"\nversion = "0.1.0"\n', '0.1.0-next.abc1234');
     expect(out).toContain('version = "0.1.0-next.abc1234"');
     expect(() => TOML.parse(out)).not.toThrow();
   });
 
-  it('keeps a literal-string table key that embeds a double quote valid', () => {
-    // Regression: the naive `'` -> `"` replacement turned
-    // `[target.'cfg(target_os = "android")'.dependencies]` into invalid TOML
-    // (`unclosed table, expected ]`), failing `cargo publish` in the release job.
+  it('keeps comments, which the release commit used to delete', () => {
+    // Regression: the version was set by re-emitting the *parsed* document, and the parser drops
+    // comments. Every release that bumped a crate silently deleted them from Cargo.toml.
     const raw = [
       '[package]',
-      'name = "demo"',
+      'name    = "demo"',
+      'version = "0.1.0"',
+      '',
+      '# UniFFI bindgen needs metadata symbols in the cdylib to generate bindings.',
+      '# Stripping removes them. Keep symbols for the ffi crate.',
+      '[profile.release.package.wvb-ffi]',
+      'strip = "none"',
+      '',
+    ].join('\n');
+
+    const out = bump(raw, '0.2.0');
+
+    expect(out).toContain('# UniFFI bindgen needs metadata symbols in the cdylib to generate');
+    expect(out).toContain('# Stripping removes them. Keep symbols for the ffi crate.');
+    // Only the version line moves; the document is otherwise handed back untouched.
+    expect(out).toBe(raw.replace('version = "0.1.0"', 'version = "0.2.0"'));
+  });
+
+  it('leaves a literal-string table key exactly as written', () => {
+    // Regression: normalizing quotes turned `[target.'cfg(target_os = "android")'.dependencies]`
+    // into invalid TOML (`unclosed table, expected ]`), failing `cargo publish` in the release job.
+    const raw = [
+      '[package]',
+      'name    = "demo"',
       'version = "0.1.0"',
       '',
       '[target.\'cfg(target_os = "android")\'.dependencies]',
@@ -35,21 +59,70 @@ describe('formatCargoToml', () => {
 
     const out = bump(raw, '0.1.0-next.abc1234');
 
-    // The literal key with an embedded `"` must stay a literal (single-quoted) string.
     expect(out).toContain('[target.\'cfg(target_os = "android")\'.dependencies]');
-    // A literal key with no embedded `"` is normalized to a basic (double-quoted) string.
-    expect(out).toContain('[target."cfg(any())".dependencies]');
-    // Above all, the result must be parseable TOML.
+    expect(out).toContain("[target.'cfg(any())'.dependencies]");
     const reparsed = parseCargoToml(out) as unknown as { target: Record<string, unknown> };
     expect(Object.keys(reparsed.target)).toContain('cfg(target_os = "android")');
   });
 
-  it('does not touch apostrophes inside basic strings', () => {
-    const out = bump(
-      '[package]\nname = "demo"\nversion = "0.1.0"\ndescription = "it\'s fine"\n',
-      '0.1.0-next.abc1234'
-    );
-    expect(out).toContain('description = "it\'s fine"');
-    expect(() => TOML.parse(out)).not.toThrow();
+  it('does not mistake `rust-version` for the package version', () => {
+    const raw =
+      '[package]\nname         = "demo"\nrust-version = "1.85.0"\nversion      = "0.1.0"\n';
+    const out = editCargoTomlVersion(raw, Version.parse('0.2.0'));
+    expect(out).toContain('rust-version = "1.85.0"');
+    expect(out).toContain('version      = "0.2.0"');
+  });
+
+  it('throws instead of inventing a `[package]` version that is not there', () => {
+    const raw = '[workspace]\nmembers = ["a"]\n';
+    expect(() => editCargoTomlVersion(raw, Version.parse('0.2.0'))).toThrow(/\[package\]/);
+  });
+});
+
+describe('editCargoTomlVersion (dependencies)', () => {
+  const raw = [
+    '[workspace.dependencies]',
+    'wvb      = { version = "0.2.0", path = "./packages/core" }',
+    'wvb-node = { version = "0.1.0", path = "./packages/node" }',
+    'serde    = "1.0"',
+    '',
+    '[dependencies]',
+    'wvb   = { workspace = true, features = ["full"] }',
+    'bytes = "1"',
+    '',
+    "[target.'cfg(any())'.dependencies]",
+    'wvb = "0.0.1"',
+    '',
+  ].join('\n');
+
+  it('sets the version inside an inline table, leaving its siblings alone', () => {
+    const out = bumpDep(raw, 'wvb', '0.3.0');
+    expect(out).toContain('wvb      = { version = "0.3.0", path = "./packages/core" }');
+    // The neighbouring entry must not be touched by a `wvb` edit.
+    expect(out).toContain('wvb-node = { version = "0.1.0", path = "./packages/node" }');
+  });
+
+  it('leaves `{ workspace = true }` alone, having no version of its own', () => {
+    const out = bumpDep(raw, 'wvb', '0.3.0');
+    expect(out).toContain('wvb   = { workspace = true, features = ["full"] }');
+  });
+
+  it('does not reach into a `[target.*.dependencies]` table', () => {
+    const out = bumpDep(raw, 'wvb', '0.3.0');
+    expect(out).toContain('[target.\'cfg(any())\'.dependencies]\nwvb = "0.0.1"');
+  });
+
+  it('sets a bare string version', () => {
+    const out = bumpDep(raw, 'serde', '2.0.0');
+    expect(out).toContain('serde    = "2.0.0"');
+  });
+
+  it('pins a prerelease exactly, so dependents never resolve across channels', () => {
+    const out = bumpDep(raw, 'wvb', '0.3.0-next.abc1234');
+    expect(out).toContain('{ version = "=0.3.0-next.abc1234", path = "./packages/core" }');
+  });
+
+  it('is a no-op for a dependency the document does not declare', () => {
+    expect(bumpDep(raw, 'not-a-dep', '9.9.9')).toBe(raw);
   });
 });

--- a/xtask/cargo-toml.ts
+++ b/xtask/cargo-toml.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import * as TOML from '@ltd/j-toml';
 import taploLib from '@taplo/lib';
-import { camelCase, mapKeys, mapValues } from 'es-toolkit';
+import { camelCase, escapeRegExp, mapKeys, mapValues } from 'es-toolkit';
 import { ROOT_DIR } from './consts.ts';
 import type { Version } from './version.ts';
 
@@ -43,93 +43,127 @@ export function parseCargoToml(raw: string): CargoToml {
   return TOML.parse(raw);
 }
 
-export function editCargoTomlVersion(toml: CargoToml, version: Version, dep?: string): void {
-  const ver = version.prerelease != null ? `=${version.toString()}` : version.toString();
-  if (dep != null) {
-    if (toml.dependencies?.[dep] != null) {
-      if (typeof toml.dependencies[dep] === 'string') {
-        toml.dependencies[dep] = ver;
-      } else if (typeof toml.dependencies[dep]?.version === 'string') {
-        toml.dependencies[dep].version = ver;
-      }
-    }
-    if (toml['dev-dependencies']?.[dep] != null) {
-      if (typeof toml['dev-dependencies'][dep] === 'string') {
-        toml['dev-dependencies'][dep] = ver;
-      } else if (typeof toml['dev-dependencies'][dep]?.version === 'string') {
-        toml['dev-dependencies'][dep].version = ver;
-      }
-    }
-    if (toml.workspace?.dependencies?.[dep] != null) {
-      if (typeof toml.workspace?.dependencies?.[dep] === 'string') {
-        toml.workspace.dependencies[dep] = ver;
-      } else if (typeof toml.workspace.dependencies[dep]?.version === 'string') {
-        toml.workspace.dependencies[dep].version = ver;
-      }
-    }
-  } else {
-    toml.package ??= {};
-    toml.package.version = version.toString();
-  }
+/** The tables a dependency's version is propagated into, paired with their parsed entries. */
+function dependencyTables(toml: CargoToml): Array<{ name: string; entries?: CargoDependencies }> {
+  return [
+    { name: 'dependencies', entries: toml.dependencies },
+    { name: 'dev-dependencies', entries: toml['dev-dependencies'] },
+    { name: 'workspace.dependencies', entries: toml.workspace?.dependencies },
+  ];
 }
 
-export function formatCargoToml(toml: CargoToml): string {
-  let content = TOML.stringify(toml as any) as any as string[];
-  content = content.slice(1);
-  content = content.filter((line, i) => {
-    const prevLine = content[i - 1];
-    return !(prevLine?.startsWith('[') === true && line === '');
-  });
-  const formatted = taplo.format(content.join('\n'), { options: taploConfig.formatting });
-  return preferDoubleQuotes(formatted);
+/** The version a declared dependency pins, or `undefined` for e.g. `{ workspace = true }`. */
+function pinnedVersionOf(value: CargoDependency | undefined): string | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  return typeof value === 'string' ? value : value.version;
+}
+
+/** Every version the document declares for `dep` — or for `[package]`, when `dep` is absent. */
+function versionsOf(toml: CargoToml, dep?: string): string[] {
+  if (dep == null) {
+    const version = toml.package?.version;
+    return version != null ? [version] : [];
+  }
+  return dependencyTables(toml)
+    .map(table => pinnedVersionOf(table.entries?.[dep]))
+    .filter(declared => declared != null);
 }
 
 /**
- * j-toml renders every string as a single-quoted TOML *literal* string, but this repo's
- * Cargo.toml style (double-quoted *basic* strings) is what `taplo` and the source files use.
- * A blanket `'` → `"` replacement is unsafe: a literal string whose content contains a `"` —
- * e.g. the `[target.'cfg(target_os = "android")'.dependencies]` key — becomes invalid TOML
- * (`unclosed table, expected ]`) once its delimiters flip to double quotes.
- *
- * This walks the document token by token: basic strings are copied verbatim (so apostrophes
- * inside them are never touched), and a literal string is converted to a basic string only when
- * its content has no `"` or `\` that would require escaping. Otherwise it is left as a literal.
+ * Rewrite the entry `key` of table `table` through `edit`, in place. Only the one matching line is
+ * handed to `edit`; every other byte of the document is left alone. Returns whether it was found
+ * *and* rewritten (`edit` returns `null` when the line holds nothing it can set).
  */
-function preferDoubleQuotes(toml: string): string {
-  let out = '';
-  for (let i = 0; i < toml.length; ) {
-    const ch = toml[i];
-    if (ch === '"') {
-      // Basic string: copy through the matching close quote, honoring backslash escapes.
-      out += ch;
-      i++;
-      while (i < toml.length) {
-        const c = toml[i];
-        out += c;
-        i++;
-        if (c === '\\' && i < toml.length) {
-          out += toml[i];
-          i++;
-        } else if (c === '"') {
-          break;
-        }
+function editEntry(
+  lines: string[],
+  table: string,
+  key: string,
+  edit: (line: string) => string | null
+): boolean {
+  // Matches `[table]` and `[[table]]` alike, so an array-of-tables also ends the preceding table.
+  const header = /^\s*\[\[?([^[\]]*)\]\]?\s*$/;
+  const entry = new RegExp(`^\\s*${escapeRegExp(key)}\\s*=`);
+  let current: string | null = null;
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i]!;
+    const matched = header.exec(line);
+    if (matched != null) {
+      current = matched[1]!.trim();
+      continue;
+    }
+    if (current !== table || !entry.test(line)) {
+      continue;
+    }
+    const edited = edit(line);
+    if (edited == null) {
+      return false;
+    }
+    lines[i] = edited;
+    return true;
+  }
+  return false;
+}
+
+/** Replace the value of a `key = "<value>"` line, keeping its spacing and any trailing comment. */
+function replaceStringValue(line: string, value: string): string | null {
+  const matched = /^(\s*[^=]+=\s*)"[^"]*"(.*)$/.exec(line);
+  return matched == null ? null : `${matched[1]}"${value}"${matched[2]}`;
+}
+
+/** Replace a dependency's version, in either the `dep = "1"` or `dep = { version = "1", .. }` form. */
+function replaceDependencyVersion(line: string, value: string): string | null {
+  const inline = /^(\s*[^=]+=\s*\{[^}]*?\bversion\s*=\s*)"[^"]*"(.*)$/.exec(line);
+  if (inline != null) {
+    return `${inline[1]}"${value}"${inline[2]}`;
+  }
+  return replaceStringValue(line, value);
+}
+
+/**
+ * Set the `[package]` version of `raw` — or, with `dep`, the version every dependency table pins
+ * `dep` at — and return the updated document.
+ *
+ * The edit is made on the text, and everything else is handed back byte for byte. Re-emitting a
+ * parsed document instead would silently drop every comment, since the TOML parser does not retain
+ * them: that quietly deleted the reasons behind `strip = "none"` and the `alloc-no-stdlib` pins on
+ * the first release after they were written.
+ */
+export function editCargoTomlVersion(raw: string, version: Version, dep?: string): string {
+  // A prerelease is pinned exactly, so a dependent never resolves across channels.
+  const wanted =
+    dep != null && version.prerelease != null ? `=${version.toString()}` : version.toString();
+  const lines = raw.split('\n');
+
+  if (dep == null) {
+    if (!editEntry(lines, 'package', 'version', line => replaceStringValue(line, wanted))) {
+      throw new Error('cannot find a `version` entry under `[package]`');
+    }
+  } else {
+    for (const table of dependencyTables(parseCargoToml(raw))) {
+      // Absent, or carrying no version of its own (`{ workspace = true }`) — nothing to set.
+      if (pinnedVersionOf(table.entries?.[dep]) == null) {
+        continue;
       }
-    } else if (ch === "'") {
-      // Literal string: content runs to the next single quote on the same line.
-      const end = toml.indexOf("'", i + 1);
-      const newline = toml.indexOf('\n', i + 1);
-      if (end !== -1 && (newline === -1 || end < newline)) {
-        const inner = toml.slice(i + 1, end);
-        out += inner.includes('"') || inner.includes('\\') ? `'${inner}'` : `"${inner}"`;
-        i = end + 1;
-      } else {
-        out += ch;
-        i++;
+      if (!editEntry(lines, table.name, dep, line => replaceDependencyVersion(line, wanted))) {
+        throw new Error(`cannot set the version of \`${dep}\` under \`[${table.name}]\``);
       }
-    } else {
-      out += ch;
-      i++;
     }
   }
-  return out;
+
+  // The edits are textual, so read them back through the parser to be sure each one landed on the
+  // value it was aimed at, rather than on some other string sharing the line.
+  const edited = lines.join('\n');
+  const wrong = versionsOf(parseCargoToml(edited), dep).filter(declared => declared !== wanted);
+  if (wrong.length > 0) {
+    throw new Error(
+      `failed to set \`${dep ?? '[package]'}\` to "${wanted}": got "${wrong.join('", "')}"`
+    );
+  }
+  return edited;
+}
+
+export function formatCargoToml(raw: string): string {
+  return taplo.format(raw, { options: taploConfig.formatting });
 }

--- a/xtask/commands/prepare-release.ts
+++ b/xtask/commands/prepare-release.ts
@@ -1,4 +1,4 @@
-import { checkbox, select } from '@inquirer/prompts';
+import { checkbox, input, select } from '@inquirer/prompts';
 import { Command, Option } from 'clipanion';
 import { type Commit, openRepository, type Repository } from 'es-git';
 import { Changelog } from '../changelog.ts';
@@ -16,14 +16,22 @@ import {
   releasePathspecs,
   writeReleaseTargets,
 } from '../releasing.ts';
-import type { BumpRule } from '../version.ts';
+import { type BumpRule, Version } from '../version.ts';
 
-type BumpChoice = BumpRule | 'skip';
+type BumpChoice = BumpRule | 'exact' | 'skip';
 
 interface ChangeChoice {
   name: string;
   value: string;
   checked: boolean;
+}
+
+function parseVersion(raw: string): Version | null {
+  try {
+    return Version.parse(raw.trim());
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -148,13 +156,17 @@ export class PrepareReleaseCommand extends Command {
       directCommits.length === 0
         ? `dependency update: ${changedDeps.map(dep => dep.name).join(', ')}`
         : 'direct changes';
-    const bump = await this.promptBump(prefix, reason);
+    const bump = await this.promptBump(prefix, pkg, reason);
     if (bump === 'skip') {
       console.log(`${prefix} skipped.`);
       return null;
     }
 
-    pkg.bumpVersion(bump);
+    if (bump === 'exact') {
+      pkg.setVersion(await this.promptExactVersion(prefix, pkg));
+    } else {
+      pkg.bumpVersion(bump);
+    }
     const changes = this.buildChanges(selectedCommitIds, summaryByCommitId, changedDeps);
     const changelog = await Changelog.load(pkg.changelog).catch(() => null);
     return { package: pkg, changes, changelog };
@@ -206,18 +218,40 @@ export class PrepareReleaseCommand extends Command {
     });
   }
 
-  private promptBump(prefix: string, reason: string): Promise<BumpChoice> {
+  private promptBump(prefix: string, pkg: Package, reason: string): Promise<BumpChoice> {
+    // `pkg.version` hands out a fresh copy, so previewing a rule never touches the package.
+    const preview = (rule: BumpRule): string => pkg.version.bump(rule).toString();
     return select<BumpChoice>({
       message: `${prefix} Select version bump (${reason})`,
       choices: [
-        { name: 'patch', value: 'patch' },
-        { name: 'minor', value: 'minor' },
-        { name: 'major', value: 'major' },
+        { name: `patch (${preview('patch')})`, value: 'patch' },
+        { name: `minor (${preview('minor')})`, value: 'minor' },
+        { name: `major (${preview('major')})`, value: 'major' },
+        { name: 'exact version', value: 'exact' },
         { name: 'skip (do not release)', value: 'skip' },
       ],
       default: 'patch',
       loop: false,
     });
+  }
+
+  /**
+   * Prompt for an explicit next version, for when no bump rule expresses the intent — typically
+   * landing several packages on one shared version. Re-prompts until the input is a version the
+   * package accepts, so a typo cannot abort a run part-way through the package list.
+   */
+  private async promptExactVersion(prefix: string, pkg: Package): Promise<Version> {
+    const raw = await input({
+      message: `${prefix} Exact version (current ${pkg.version.toString()})`,
+      validate: value => {
+        const version = parseVersion(value);
+        if (version == null) {
+          return `invalid version: ${value.trim()}`;
+        }
+        return pkg.rejectVersion(version) ?? true;
+      },
+    });
+    return parseVersion(raw)!;
   }
 
   /** Turn the selected commits (+ an automatic dependency-bump note) into changelog entries. */

--- a/xtask/package.json
+++ b/xtask/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/xtask/package.ts
+++ b/xtask/package.ts
@@ -231,6 +231,35 @@ export class Package {
     return this;
   }
 
+  /**
+   * Why `version` cannot be this package's next version, or `null` when it can. It has to be ahead
+   * of *every* manifest: `release` only publishes what the merge commit raised, and a package's
+   * nested manifests (e.g. the napi platform packages) must not be walked backwards.
+   */
+  rejectVersion(version: Version): string | null {
+    const blocking = this.versionedFiles.find(file => !version.greaterThan(file.version));
+    return blocking == null
+      ? null
+      : `${blocking.name} is already at ${blocking.version.toString()}`;
+  }
+
+  /**
+   * Set every manifest's pending version to `version`, instead of deriving it from a bump rule.
+   * Unlike {@link bumpVersion} — which advances each manifest from its own version — this lands
+   * them all on one version, so a package's manifests can be aligned with each other (and with
+   * other packages).
+   */
+  setVersion(version: Version): this {
+    const reason = this.rejectVersion(version);
+    if (reason != null) {
+      throw new Error(`cannot set ${this.name} to ${version.toString()}: ${reason}`);
+    }
+    for (const versionedFile of this.versionedFiles) {
+      versionedFile.setVersion(version);
+    }
+    return this;
+  }
+
   /** Set every manifest's pending version to a prerelease of its current version. */
   bumpPrerelease(id: string, build: string): this {
     for (const versionedFile of this.versionedFiles) {

--- a/xtask/releasing.spec.ts
+++ b/xtask/releasing.spec.ts
@@ -3,6 +3,7 @@ import type { PackageConfig } from './config.ts';
 import { Package } from './package.ts';
 import type { Ports } from './ports.ts';
 import { observePublishState, planPackagePublish, publishPackage } from './releasing.ts';
+import { Version } from './version.ts';
 import { VersionedFile } from './versioned-file.ts';
 
 function npmManifest(
@@ -109,6 +110,38 @@ describe('deno.json manifest', () => {
     });
     // The source scan is empty (fixture dir does not exist), so only the imports keys remain.
     expect(file.dependencyNames).toEqual(['@wvb/deno', '@std/path']);
+  });
+});
+
+describe('Package#setVersion', () => {
+  it('lands every manifest on the given version, whatever each started from', () => {
+    const pkg = makePackage([
+      crateManifest('wvb-tauri', '0.1.0'),
+      crateManifest('wvb-tauri-e2e-app', '0.0.0', { publish: false }),
+    ]);
+    pkg.setVersion(Version.parse('0.3.0'));
+    expect(pkg.versionedFiles.map(f => f.nextVersion.toString())).toEqual(['0.3.0', '0.3.0']);
+    expect(pkg.hasChanged).toBe(true);
+  });
+
+  it('rejects a version that is not ahead of the package', () => {
+    const pkg = makePackage([crateManifest('wvb', '0.2.0')]);
+    expect(pkg.rejectVersion(Version.parse('0.2.0'))).toBe('wvb is already at 0.2.0');
+    expect(pkg.rejectVersion(Version.parse('0.1.0'))).toBe('wvb is already at 0.2.0');
+    expect(pkg.rejectVersion(Version.parse('0.3.0'))).toBeNull();
+  });
+
+  it('rejects a version that would walk a nested manifest backwards', () => {
+    const pkg = makePackage([
+      npmManifest('@wvb/node', '0.1.0'),
+      npmManifest('@wvb/node-darwin-arm64', '0.4.0'),
+    ]);
+    expect(pkg.rejectVersion(Version.parse('0.3.0'))).toBe(
+      '@wvb/node-darwin-arm64 is already at 0.4.0'
+    );
+    expect(() => pkg.setVersion(Version.parse('0.3.0'))).toThrow(/cannot set test to 0\.3\.0/);
+    // All-or-nothing: the leading manifest must not keep a version the package refused.
+    expect(pkg.hasChanged).toBe(false);
   });
 });
 

--- a/xtask/releasing.ts
+++ b/xtask/releasing.ts
@@ -155,17 +155,17 @@ async function writeRootCargoToml(targets: ReleaseTarget[], dryRun: boolean): Pr
     return false;
   }
   const raw = await fs.readFile(path.join(ROOT_DIR, 'Cargo.toml'), 'utf8');
-  const toml = parseCargoToml(raw);
+  let edited = raw;
   for (const target of targets) {
     for (const versionedFile of target.package.versionedFiles) {
       if (versionedFile.type !== 'Cargo.toml') {
         continue;
       }
-      editCargoTomlVersion(toml, versionedFile.nextVersion, versionedFile.name);
+      edited = editCargoTomlVersion(edited, versionedFile.nextVersion, versionedFile.name);
     }
   }
   await runActions(
-    [{ type: 'write', path: 'Cargo.toml', content: formatCargoToml(toml), prevContent: raw }],
+    [{ type: 'write', path: 'Cargo.toml', content: formatCargoToml(edited), prevContent: raw }],
     { dryRun }
   );
   return true;

--- a/xtask/versioned-file.ts
+++ b/xtask/versioned-file.ts
@@ -150,6 +150,11 @@ export class VersionedFile {
     this._nextVersion.bump(rule);
   }
 
+  /** Set the pending version to an exact version, instead of deriving it from a bump rule. */
+  setVersion(version: Version): void {
+    this._nextVersion = version.clone();
+  }
+
   /** Set the pending version to a prerelease of the current version (`x.y.z-<id>.<build>`). */
   setPrerelease(id: string, build: string): void {
     this._nextVersion = this.pkgManager.version.clone();
@@ -303,9 +308,7 @@ class Cargo implements PackageManager {
   }
 
   write(nextVersion: Version): Action[] {
-    const edited = parseCargoToml(this.raw);
-    editCargoTomlVersion(edited, nextVersion);
-    const content = formatCargoToml(edited);
+    const content = formatCargoToml(editCargoTomlVersion(this.raw, nextVersion));
 
     return [
       {

--- a/xtask/vitest.config.ts
+++ b/xtask/vitest.config.ts
@@ -1,6 +1,6 @@
-import { defineProject } from 'vitest/config';
+import { defineConfig } from 'vitest/config';
 
-export default defineProject({
+export default defineConfig({
   test: {
     clearMocks: true,
     environment: 'node',


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/webview-bundle/webview-bundle/pull/216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

