### PR TITLE
fix: remove `hickory_dns` field in `HttpOptions`

### DIFF
--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -78,7 +78,6 @@ remote = [
   "_serde",
   "reqwest/rustls-tls",
   "reqwest/json",
-  "reqwest/hickory-dns",
   "reqwest/stream",
   "dep:urlencoding",
   "dep:futures-util",

--- a/packages/core/src/remote/http.rs
+++ b/packages/core/src/remote/http.rs
@@ -17,7 +17,6 @@ pub struct HttpOptions {
   pub pool_max_idle_per_host: Option<usize>,
   pub referer: Option<bool>,
   pub tcp_nodelay: Option<bool>,
-  pub hickory_dns: Option<bool>,
 }
 
 impl HttpOptions {
@@ -70,11 +69,6 @@ impl HttpOptions {
     self
   }
 
-  pub fn hickory_dns(mut self, hickory_dns: bool) -> Self {
-    self.hickory_dns = Some(hickory_dns);
-    self
-  }
-
   pub(crate) fn apply(&self, mut http: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
     if let Some(default_headers) = self.default_headers.as_ref() {
       http = http.default_headers(default_headers.clone());
@@ -95,9 +89,6 @@ impl HttpOptions {
     }
     if let Some(tcp_nodelay) = self.tcp_nodelay {
       http = http.tcp_nodelay(tcp_nodelay);
-    }
-    if let Some(hickory_dns) = self.hickory_dns {
-      http = http.hickory_dns(hickory_dns);
     }
     http
   }

--- a/packages/core/src/remote/http.rs
+++ b/packages/core/src/remote/http.rs
@@ -96,6 +96,9 @@ impl HttpOptions {
     if let Some(tcp_nodelay) = self.tcp_nodelay {
       http = http.tcp_nodelay(tcp_nodelay);
     }
+    if let Some(hickory_dns) = self.hickory_dns {
+      http = http.hickory_dns(hickory_dns);
+    }
     http
   }
 }

--- a/packages/deno/src/lib.rs
+++ b/packages/deno/src/lib.rs
@@ -671,9 +671,6 @@ fn parse_http_options(raw: &str) -> Option<HttpOptions> {
   if let Some(x) = value.get("tcpNodelay").and_then(|x| x.as_bool()) {
     options = options.tcp_nodelay(x);
   }
-  if let Some(x) = value.get("hickoryDns").and_then(|x| x.as_bool()) {
-    options = options.hickory_dns(x);
-  }
   Some(options)
 }
 

--- a/packages/ffi/src/remote.rs
+++ b/packages/ffi/src/remote.rs
@@ -33,8 +33,6 @@ pub struct HttpOptions {
   pub referer: Option<bool>,
   #[uniffi(default = None)]
   pub tcp_nodelay: Option<bool>,
-  #[uniffi(default = None)]
-  pub hickory_dns: Option<bool>,
 }
 
 impl TryFrom<HttpOptions> for remote::HttpOptions {
@@ -68,9 +66,6 @@ impl TryFrom<HttpOptions> for remote::HttpOptions {
     }
     if let Some(tcp_nodelay) = value.tcp_nodelay {
       options = options.tcp_nodelay(tcp_nodelay);
-    }
-    if let Some(hickory_dns) = value.hickory_dns {
-      options = options.hickory_dns(hickory_dns);
     }
     Ok(options)
   }

--- a/packages/node/src/remote/http.rs
+++ b/packages/node/src/remote/http.rs
@@ -14,7 +14,6 @@ pub struct HttpOptions {
   pub pool_max_idle_per_host: Option<u32>,
   pub referer: Option<bool>,
   pub tcp_nodelay: Option<bool>,
-  pub hickory_dns: Option<bool>,
 }
 
 impl TryFrom<HttpOptions> for wvb::remote::HttpOptions {
@@ -53,9 +52,6 @@ impl TryFrom<HttpOptions> for wvb::remote::HttpOptions {
     }
     if let Some(tcp_nodelay) = value.tcp_nodelay {
       options = options.tcp_nodelay(tcp_nodelay);
-    }
-    if let Some(hickory_dns) = value.hickory_dns {
-      options = options.hickory_dns(hickory_dns);
     }
     Ok(options)
   }


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/webview-bundle/webview-bundle/pull/224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

