### PR TITLE
fix(electron-builder, electron-forge): defer builtin-empty check to install result

### DIFF
--- a/packages/electron-builder/src/setup.ts
+++ b/packages/electron-builder/src/setup.ts
@@ -47,18 +47,7 @@ export function webviewBundleAfterPack(
       configFile: configFile === true ? undefined : configFile,
     });
 
-    if (resolved.builtin == null) {
-      if (throwWhenBuiltinIsEmpty) {
-        throw new Error(
-          'No "builtin" config was resolved. Add a `builtin` block to your webview-bundle config ' +
-            '(or pass it inline to the integration), or set `throwWhenBuiltinIsEmpty: false` to ' +
-            'build without builtin bundles.'
-        );
-      }
-      return;
-    }
-
-    const { target, outDir, include, exclude, clean } = resolved.builtin;
+    const { target, outDir, include, exclude, clean } = resolved.builtin ?? {};
 
     // Don't mutate the resolved config: `resolved.builtin` may share its reference with the inline
     // options, and electron-builder invokes `afterPack` once per (platform, arch). Build a fresh

--- a/packages/electron-forge/src/plugin.ts
+++ b/packages/electron-forge/src/plugin.ts
@@ -58,18 +58,7 @@ export class WebviewBundlePlugin extends PluginBase<WebviewBundlePluginConfig> {
       configFile: configFile === true ? undefined : configFile,
     });
 
-    if (resolved.builtin == null) {
-      if (throwWhenBuiltinIsEmpty) {
-        throw new Error(
-          'No "builtin" config was resolved. Add a `builtin` block to your webview-bundle config ' +
-            '(or pass it inline to WebviewBundlePlugin), or set `throwWhenBuiltinIsEmpty: false` to ' +
-            'build without builtin bundles.'
-        );
-      }
-      return;
-    }
-
-    const { target, outDir, include, exclude, clean } = resolved.builtin;
+    const { target, outDir, include, exclude, clean } = resolved.builtin ?? {};
 
     // Don't mutate the resolved config: `resolved.builtin` may share its reference with `this.config`,
     // and forge invokes `packageAfterCopy` once per (platform, arch). Build a fresh target instead.


### PR DESCRIPTION
## Summary

The `WebviewBundlePlugin` (electron-forge) and `webviewBundleAfterPack` (electron-builder) threw immediately when no `builtin` block was resolved from config, forcing consumers to pass a redundant `builtin: {}` even though adding the integration already signals intent.

But `builtin` defaults to a remote install from `remote.endpoint`, so an absent block is a valid "install from remote with defaults" case — not a misconfiguration. This drops the early `resolved.builtin == null` throw, resolves `builtin` to defaults (`{}`), and runs the install. `throwWhenBuiltinIsEmpty` (default `true`) now fires **only when the actual install yields zero bundles** — i.e. after the config is fully resolved and executed.

Net effect: `new WebviewBundlePlugin()` / `withWebviewBundle(config)` now "just work" against a remote endpoint, while an empty install is still caught.

## Test Plan

- `yarn workspace @wvb/electron-forge typecheck` ✅
- `yarn workspace @wvb/electron-builder typecheck` ✅
- No existing spec covered the removed early-throw branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/webview-bundle/webview-bundle/pull/226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

