### PR TITLE
fix(core): handle Windows delete-pending bundle reads

### DIFF
--- a/packages/core/src/source/source.rs
+++ b/packages/core/src/source/source.rs
@@ -681,7 +681,9 @@ fn is_windows_reserved_name(value: &str) -> bool {
 }
 
 fn map_read_error(e: std::io::Error) -> crate::Error {
-  if e.kind() == std::io::ErrorKind::NotFound {
+  if e.kind() == std::io::ErrorKind::NotFound
+    || (cfg!(windows) && e.kind() == std::io::ErrorKind::PermissionDenied)
+  {
     return crate::Error::BundleNotFound;
   }
   crate::Error::from(e)
@@ -745,6 +747,27 @@ mod tests {
     ] {
       assert!(!is_valid_path_component(bad), "{bad:?} should be invalid");
     }
+  }
+
+  #[test]
+  fn map_read_error_treats_missing_file_as_bundle_not_found() {
+    let e = std::io::Error::from(std::io::ErrorKind::NotFound);
+    assert!(matches!(map_read_error(e), crate::Error::BundleNotFound));
+  }
+
+  #[cfg(windows)]
+  #[test]
+  fn map_read_error_treats_delete_pending_as_bundle_not_found() {
+    let e = std::io::Error::from_raw_os_error(5);
+    assert_eq!(e.kind(), std::io::ErrorKind::PermissionDenied);
+    assert!(matches!(map_read_error(e), crate::Error::BundleNotFound));
+  }
+
+  #[cfg(not(windows))]
+  #[test]
+  fn map_read_error_keeps_permission_denied_as_io() {
+    let e = std::io::Error::from(std::io::ErrorKind::PermissionDenied);
+    assert!(matches!(map_read_error(e), crate::Error::Io(_)));
   }
 
   #[test]


### PR DESCRIPTION
## Summary

`test-rust (windows-latest)` flakes on `repeated_swaps_stay_valid` in `packages/core/tests/concurrency.rs`:

```
a failed read must be a clean BundleNotFound, got: io error: Access is denied. (os error 5)
```

A bundle file resolved from a descriptor can be pruned by a concurrent install before it is opened, and `map_read_error` only mapped `NotFound → BundleNotFound`:

- **POSIX** reports the racing open as `NotFound` → clean `BundleNotFound` (contract holds).
- **Windows** puts the file into a *delete-pending* state: until the last handle closes, opening it fails with `ERROR_ACCESS_DENIED` (os error 5 → `PermissionDenied`), which leaked through as a raw `Error::Io` and tripped the test's assertion.

This maps Windows `PermissionDenied → BundleNotFound` in that one spot — gated by `cfg!(windows)`, so POSIX still surfaces genuine permission errors — restoring the "a pruned read fails only as a clean `BundleNotFound`, never a raw IO error" contract on every platform.

Pre-existing since #152; not introduced by a recent change — a timing race this run happened to lose.

## Test Plan

- `cargo test -p wvb --all-features --test concurrency` — 9/9 pass (incl. `repeated_swaps_stay_valid`)
- `cargo test -p wvb --all-features --lib map_read_error` — new unit tests pass; a `#[cfg(windows)]` test asserts `from_raw_os_error(5)` → `BundleNotFound` (runs in Windows CI)
- `cargo fmt --check` clean · `cargo clippy --all-features --tests` clean
- macOS behavior is unchanged (`cfg!(windows)` is false); Windows CI validates the mapped branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2fichjyKbmnj8LhHE4whJ


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/webview-bundle/webview-bundle/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

